### PR TITLE
Address all 2026-05-17 agent feedback (15 issues)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ### Added
 - **Canvas Integration (22 nuevas herramientas)**: Soporte completo para ficheros `.canvas` de Obsidian con dos capas:
-  - **8 herramientas genéricas** (`canvas_read`, `canvas_list`, `canvas_add_card`, `canvas_add_group`, `canvas_add_edge`, `canvas_update_card`, `canvas_remove_card`, `canvas_remove_edge`) para CRUD sobre cualquier canvas.
-  - **14 herramientas de workflow Kanvas** (`kanvas_init`, `kanvas_status`, `kanvas_task`, `kanvas_ready`, `kanvas_blocked`, `kanvas_start`, `kanvas_finish`, `kanvas_pause`, `kanvas_approve`, `kanvas_complete`, `kanvas_edit_task`, `kanvas_add_dependency`, `kanvas_propose_task`, `kanvas_propose_group`) para gestión de proyectos con estados codificados por color (gris=bloqueado, rojo=pendiente, naranja=en curso, cian=revisión, verde=hecho, morado=propuesto).
+  - **8 herramientas genéricas** (`canvas.read`, `canvas.list`, `canvas.add_card`, `canvas.add_group`, `canvas.add_edge`, `canvas.update_card`, `canvas.remove_card`, `canvas.remove_edge`) para CRUD sobre cualquier canvas.
+  - **14 herramientas de workflow Kanvas** (`kanvas.init`, `kanvas.status`, `kanvas.task`, `kanvas.ready`, `kanvas.blocked`, `kanvas.start`, `kanvas.finish`, `kanvas.pause`, `kanvas.approve`, `kanvas.complete`, `kanvas.edit_task`, `kanvas.add_dependency`, `kanvas.propose_task`, `kanvas.propose_group`) para gestión de proyectos con estados codificados por color (gris=bloqueado, rojo=pendiente, naranja=en curso, cian=revisión, verde=hecho, morado=propuesto).
   - Dos modos de workflow: **STRICT** (solo el humano aprueba/completa) y **RELAXED** (el agente también puede).
   - Detección automática de ciclos en dependencias entre tareas.
   - Normalización automática de estados (bloqueos) al guardar.
@@ -32,7 +32,7 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - **QA Code Coverage**: Arreglados todos los avisos estrictos de `pylint` (reduciendo la complejidad ciclomática explícita y gestionando *lazy loading* de paquetes RAG).
 - **Vulnerabilidades Corregidas**: Mitigadas 2 vulnerabilidades moderadas/altas (CVEs) encontradas en dependencias secundarias (`authlib` y `diskcache`) vía `uv sync --upgrade`.
 - **Tag Extraction**: Filtro de códigos de color hexadecimales (`#fff`, etc.) en `extract_tags_from_content` para evitar falsos positivos.
-- **Tag Sync**: Búsqueda flexible (regex) del encabezado de estadísticas en el Registro de Tags y fallback de creación iterativo si no existe en `sync_tag_registry`.
+- **Tag Sync**: Búsqueda flexible (regex) del encabezado de estadísticas en el Registro de Tags y fallback de creación iterativo si no existe en `tags.sync_registry`.
 - **Import circular** en `security.py` que impedía el arranque del servidor MCP. El import de `vault_config` se movió a nivel de función para romper el ciclo de dependencias.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ profile:
 ```
 
 Then read `obsidian://integrations/obsidianrag/setup` or call
-`rag_setup_status`. Agents should show setup commands before installing
+`rag.setup_status`. Agents should show setup commands before installing
 dependencies, starting services, pulling models, or rebuilding the index.
 
 ### Cursor & Cline Integration

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -1,0 +1,45 @@
+# Agent Quickstart
+
+A short orientation for AI agents using the Obsidian MCP server. Read this once at the start of a session and you'll skip a lot of trial-and-error.
+
+## First two calls
+
+1. `read_vault_context()` — folder layout, templates, common tags, active profile.
+2. `get_global_rules()` — vault-wide author rules (frontmatter required fields, heading conventions, etc.). The server enforces these on every write and surfaces violations in the response; reading them upfront tells you what to comply with.
+
+After those two calls you have enough context to write correctly. Everything below is a "when you need it" reference.
+
+## Decision table — pick the right tool
+
+| You need to… | Use |
+|---|---|
+| List notes in the vault | `list_notes(folder=, limit=500, offset=0, pattern=)` — paginates by default |
+| Read one note | `read_note(note_path)` |
+| Read several notes | `read_notes(paths=[...])` — note: `paths`, not `query=` |
+| Search by text | `search_notes(query=, titles_only=False)` |
+| Search by date | `search_notes_by_date(date_from, date_to)` |
+| Create a note | `create_note(title, content, folder, tags, ...)` — embed YAML frontmatter in `content` and it'll be merged with parameters |
+| Lint a note before writing | `validate_note(content, title, mode='create')` — pre-flight, no write |
+| Edit fragments of a note | `patch_note(note_path, operations=[{old, new}, ...])` — fuzzy suggestions on miss |
+| Replace whole note body | `replace_note(note_path, content)` — requires client elicit() support |
+| Delete a note | `delete_note(note_path)` — requires client elicit() support |
+| Rename a note + update wikilinks | `rename_note(source, new_name, update_links=True)` |
+| Move a note | `move_note(source, destination, update_links=True)` |
+| Find broken wikilinks across the vault | `find_broken_wikilinks(limit=100)` — returns source file + line + fuzzy suggestions |
+| Link/orphan analysis | `analyze_links()`, `find_orphan_notes()` |
+| Bulk find/replace text | `preview_replace_in_notes(...)` then `apply_replace_in_notes(...)` |
+| Vault stats / tag audit | `get_vault_stats()`, `analyze_tags()`, `list_tags()` |
+| Routing help | `route_task(request)` — suggests prompts/skills/tools for an ambiguous task |
+
+## Common traps
+
+- **`read_notes` argument name** is `paths` (a list), not `query`. Pydantic will reject `query=`.
+- **Tags passed as a string** like `"astro, equipo"` are normalized to a YAML list in frontmatter. This is intentional but undocumented in the field name.
+- **Embedded frontmatter wins**: if your `create_note` content starts with `---...---`, fields like `type` and `status` are preserved over parameter-derived defaults (since v post-2026-05-17).
+- **`delete_note` / `replace_note`** require an MCP client that supports `elicit()` for confirmation. If your host can't surface the prompt you'll get a specific Spanish error explaining what to try instead — don't fall back to `rm` or full-file `patch_note` without checking the message.
+- **Vault-rule warnings** appear in the response of `create_note` / `patch_note` etc. when content violates the rules. The full rule prose is only attached when violations are present; for clean writes the server emits a compact pointer back to `get_global_rules()`.
+- **`list_notes` is paginated** at 500 notes by default. Pass `limit=0` for "everything" on small vaults, or watch the `Truncated:` footer for the next `offset`.
+
+## When in doubt
+
+Call `route_task("I need to X")` — it returns the right combination of prompts, skills, and tool calls for vague requests.

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -4,8 +4,8 @@ A short orientation for AI agents using the Obsidian MCP server. Read this once 
 
 ## First two calls
 
-1. `read_vault_context()` — folder layout, templates, common tags, active profile.
-2. `get_global_rules()` — vault-wide author rules (frontmatter required fields, heading conventions, etc.). The server enforces these on every write and surfaces violations in the response; reading them upfront tells you what to comply with.
+1. `vault.context()` — folder layout, templates, common tags, active profile.
+2. `rules.get()` — vault-wide author rules (frontmatter required fields, heading conventions, etc.). The server enforces these on every write and surfaces violations in the response; reading them upfront tells you what to comply with.
 
 After those two calls you have enough context to write correctly. Everything below is a "when you need it" reference.
 
@@ -13,34 +13,34 @@ After those two calls you have enough context to write correctly. Everything bel
 
 | You need to… | Use |
 |---|---|
-| List notes in the vault | `list_notes(folder=, limit=500, offset=0, pattern=)` — paginates by default |
-| Read one note | `read_note(note_path)` |
-| Read several notes | `read_notes(paths=[...])` — note: `paths`, not `query=` |
-| Search by text | `search_notes(query=, titles_only=False)` |
-| Search by date | `search_notes_by_date(date_from, date_to)` |
-| Create a note | `create_note(title, content, folder, tags, ...)` — embed YAML frontmatter in `content` and it'll be merged with parameters |
-| Lint a note before writing | `validate_note(content, title, mode='create')` — pre-flight, no write |
-| Edit fragments of a note | `patch_note(note_path, operations=[{old, new}, ...])` — fuzzy suggestions on miss |
-| Replace whole note body | `replace_note(note_path, content)` — requires client elicit() support |
-| Delete a note | `delete_note(note_path)` — requires client elicit() support |
-| Rename a note + update wikilinks | `rename_note(source, new_name, update_links=True)` |
-| Move a note | `move_note(source, destination, update_links=True)` |
-| Find broken wikilinks across the vault | `find_broken_wikilinks(limit=100)` — returns source file + line + fuzzy suggestions |
-| Link/orphan analysis | `analyze_links()`, `find_orphan_notes()` |
-| Bulk find/replace text | `preview_replace_in_notes(...)` then `apply_replace_in_notes(...)` |
-| Lint every note against vault rules (heading emojis, missing frontmatter fields, etc.) | `lint_vault(auto_fix=False)` to scan, then `lint_vault(auto_fix=True)` to apply regex-based fixes |
-| Vault stats / tag audit | `get_vault_stats()`, `analyze_tags()`, `list_tags()` |
-| Routing help | `route_task(request)` — suggests prompts/skills/tools for an ambiguous task |
+| List notes in the vault | `notes.list(folder=, limit=500, offset=0, pattern=)` — paginates by default |
+| Read one note | `notes.read(note_path)` |
+| Read several notes | `notes.read_many(paths=[...])` — note: `paths`, not `query=` |
+| Search by text | `notes.search(query=, titles_only=False)` |
+| Search by date | `notes.search_by_date(date_from, date_to)` |
+| Create a note | `notes.create(title, content, folder, tags, ...)` — embed YAML frontmatter in `content` and it'll be merged with parameters |
+| Lint a note before writing | `notes.validate(content, title, mode='create')` — pre-flight, no write |
+| Edit fragments of a note | `notes.patch(note_path, operations=[{old, new}, ...])` — fuzzy suggestions on miss |
+| Replace whole note body | `notes.replace(note_path, content)` — requires client elicit() support |
+| Delete a note | `notes.delete(note_path)` — requires client elicit() support |
+| Rename a note + update wikilinks | `notes.rename(source, new_name, update_links=True)` |
+| Move a note | `notes.move(source, destination, update_links=True)` |
+| Find broken wikilinks across the vault | `links.find_broken(limit=100)` — returns source file + line + fuzzy suggestions |
+| Link/orphan analysis | `links.analyze()`, `links.find_orphans()` |
+| Bulk find/replace text | `notes.preview_replace(...)` then `notes.apply_replace(...)` |
+| Lint every note against vault rules (heading emojis, missing frontmatter fields, etc.) | `vault.lint(auto_fix=False)` to scan, then `vault.lint(auto_fix=True)` to apply regex-based fixes |
+| Vault stats / tag audit | `vault.stats()`, `tags.analyze()`, `tags.list()` |
+| Routing help | `route.task(request)` — suggests prompts/skills/tools for an ambiguous task |
 
 ## Common traps
 
-- **`read_notes` argument name** is `paths` (a list), not `query`. Pydantic will reject `query=`.
+- **`notes.read_many` argument name** is `paths` (a list), not `query`. Pydantic will reject `query=`.
 - **Tags passed as a string** like `"astro, equipo"` are normalized to a YAML list in frontmatter. This is intentional but undocumented in the field name.
-- **Embedded frontmatter wins**: if your `create_note` content starts with `---...---`, fields like `type` and `status` are preserved over parameter-derived defaults (since v post-2026-05-17).
-- **`delete_note` / `replace_note`** require an MCP client that supports `elicit()` for confirmation. If your host can't surface the prompt you'll get a specific Spanish error explaining what to try instead — don't fall back to `rm` or full-file `patch_note` without checking the message.
-- **Vault-rule warnings** appear in the response of `create_note` / `patch_note` etc. when content violates the rules. The full rule prose is only attached when violations are present; for clean writes the server emits a compact pointer back to `get_global_rules()`.
-- **`list_notes` is paginated** at 500 notes by default. Pass `limit=0` for "everything" on small vaults, or watch the `Truncated:` footer for the next `offset`.
+- **Embedded frontmatter wins**: if your `notes.create` content starts with `---...---`, fields like `type` and `status` are preserved over parameter-derived defaults (since v post-2026-05-17).
+- **`notes.delete` / `notes.replace`** require an MCP client that supports `elicit()` for confirmation. If your host can't surface the prompt you'll get a specific Spanish error explaining what to try instead — don't fall back to `rm` or full-file `notes.patch` without checking the message.
+- **Vault-rule warnings** appear in the response of `notes.create` / `notes.patch` etc. when content violates the rules. The full rule prose is only attached when violations are present; for clean writes the server emits a compact pointer back to `rules.get()`.
+- **`notes.list` is paginated** at 500 notes by default. Pass `limit=0` for "everything" on small vaults, or watch the `Truncated:` footer for the next `offset`.
 
 ## When in doubt
 
-Call `route_task("I need to X")` — it returns the right combination of prompts, skills, and tool calls for vague requests.
+Call `route.task("I need to X")` — it returns the right combination of prompts, skills, and tool calls for vague requests.

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -28,6 +28,7 @@ After those two calls you have enough context to write correctly. Everything bel
 | Find broken wikilinks across the vault | `find_broken_wikilinks(limit=100)` — returns source file + line + fuzzy suggestions |
 | Link/orphan analysis | `analyze_links()`, `find_orphan_notes()` |
 | Bulk find/replace text | `preview_replace_in_notes(...)` then `apply_replace_in_notes(...)` |
+| Lint every note against vault rules (heading emojis, missing frontmatter fields, etc.) | `lint_vault(auto_fix=False)` to scan, then `lint_vault(auto_fix=True)` to apply regex-based fixes |
 | Vault stats / tag audit | `get_vault_stats()`, `analyze_tags()`, `list_tags()` |
 | Routing help | `route_task(request)` — suggests prompts/skills/tools for an ambiguous task |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,7 +179,7 @@ opt-ins:
 - `legacy_semantic`: deprecated in-process semantic search. Prefer
   `obsidianrag`; this pack is kept only for backwards compatibility.
 
-Use `list_client_roots()` to inspect roots advertised by clients that support
+Use `client.roots()` to inspect roots advertised by clients that support
 the MCP `roots/list` capability. This is useful during setup because an agent
 can confirm which workspaces or vault folders the client has made visible.
 
@@ -195,11 +195,11 @@ server. New deployments should use ObsidianRAG instead.
 
 The server then exposes:
 
-- `rag_setup_status()`: detects the configured project, backend, `uv`, Ollama
+- `rag.setup_status()`: detects the configured project, backend, `uv`, Ollama
   CLI/API, and ObsidianRAG API health.
 - `obsidian://integrations/obsidianrag/setup`: a setup playbook with exact
   commands, safe shell quoting, and optional environment variables.
-- `rag_health()` and `rebuild_rag_index()` for readiness and first indexing.
+- `rag.health()` and `rag.rebuild_index()` for readiness and first indexing.
 
 Agents must ask for consent before installing dependencies, pulling models,
 starting local services, or rebuilding a large index.

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -31,10 +31,10 @@ profile:
 
 Useful tools and resources:
 
-- `rag_setup_status()`: inspect local prerequisites and backend reachability.
-- `rag_health()`: check whether the ObsidianRAG API is healthy.
-- `ask_vault(question, session_id)`: ask semantic questions against the vault.
-- `rebuild_rag_index()`: trigger a backend index rebuild.
+- `rag.setup_status()`: inspect local prerequisites and backend reachability.
+- `rag.health()`: check whether the ObsidianRAG API is healthy.
+- `rag.ask(question, session_id)`: ask semantic questions against the vault.
+- `rag.rebuild_index()`: trigger a backend index rebuild.
 - `obsidian://integrations/obsidianrag/setup`: guided setup playbook.
 - `obsidian://integrations/obsidianrag/config`: safe integration summary.
 
@@ -46,9 +46,9 @@ inside this MCP server.
 
 Legacy tools:
 
-- `semantic_search`
-- `index_vault_semantic`
-- `suggest_semantic_connections`
+- `semantic.search`
+- `semantic.index`
+- `semantic.suggest_connections`
 
 They require the deprecated optional dependency extra:
 
@@ -67,12 +67,12 @@ For a vault currently using `legacy_semantic`:
 1. Install and start ObsidianRAG.
 2. Enable the `obsidianrag` tool set in `.agents/vault.yaml`.
 3. Configure the ObsidianRAG project path and local API URL.
-4. Run `rag_setup_status()` and follow the setup resource.
+4. Run `rag.setup_status()` and follow the setup resource.
 5. Rebuild the ObsidianRAG index once.
 6. Replace legacy calls:
-   - `semantic_search` -> `ask_vault`
-   - `index_vault_semantic` -> `rebuild_rag_index`
-   - `suggest_semantic_connections` -> use ObsidianRAG retrieval plus explicit
+   - `semantic.search` -> `rag.ask`
+   - `semantic.index` -> `rag.rebuild_index`
+   - `semantic.suggest_connections` -> use ObsidianRAG retrieval plus explicit
      link-analysis tools until a dedicated external suggestion workflow exists.
 
 Once no active client depends on `legacy_semantic`, the legacy package extra and

--- a/docs/superpowers/specs/2026-03-28-canvas-integration-design.md
+++ b/docs/superpowers/specs/2026-03-28-canvas-integration-design.md
@@ -158,14 +158,14 @@ Tools for reading/writing any `.canvas` file. No workflow assumptions.
 
 | Tool | Description |
 |------|-------------|
-| `canvas_read(canvas_path)` | Read canvas summary: nodes, edges, groups (human-readable, not raw JSON) |
-| `canvas_list(folder="")` | List all `.canvas` files in the vault or a folder |
-| `canvas_add_card(canvas_path, text, group="", color="", width=280, height=160)` | Add a text card, optionally inside a group |
-| `canvas_add_group(canvas_path, label)` | Create a group/area |
-| `canvas_add_edge(canvas_path, from_id, to_id, label="")` | Connect two nodes with an arrow |
-| `canvas_update_card(canvas_path, node_id, text="", color="")` | Update text and/or color of a card |
-| `canvas_remove_card(canvas_path, node_id)` | Delete a card and its edges |
-| `canvas_remove_edge(canvas_path, edge_id)` | Delete a connection |
+| `canvas.read(canvas_path)` | Read canvas summary: nodes, edges, groups (human-readable, not raw JSON) |
+| `canvas.list(folder="")` | List all `.canvas` files in the vault or a folder |
+| `canvas.add_card(canvas_path, text, group="", color="", width=280, height=160)` | Add a text card, optionally inside a group |
+| `canvas.add_group(canvas_path, label)` | Create a group/area |
+| `canvas.add_edge(canvas_path, from_id, to_id, label="")` | Connect two nodes with an arrow |
+| `canvas.update_card(canvas_path, node_id, text="", color="")` | Update text and/or color of a card |
+| `canvas.remove_card(canvas_path, node_id)` | Delete a card and its edges |
+| `canvas.remove_edge(canvas_path, edge_id)` | Delete a connection |
 
 ## Workflow tools (16 tools)
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -81,6 +81,10 @@ Optional tools are enabled from `.agents/vault.yaml` with
 - `get_notes_by_tag(tag)`: Find notes with a tag.
 - `get_local_graph(note_path, depth)`: Explore local graph connections.
 - `find_orphan_notes()`: Find notes without incoming or outgoing links.
+- `lint_vault(folder, rule_ids, auto_fix, limit)`: Run vault rules across
+  every note in one sweep (Issue #9). With `auto_fix=True` the
+  regex-based heading/body rules are rewritten in place; frontmatter
+  rules remain report-only because they need semantic input.
 - `find_broken_wikilinks(limit=100)`: List every `[[target]]` in the vault
   whose target note doesn't exist. Returns source file + line + fuzzy
   match suggestions per broken reference (Issue #6). Pair with `rename_note`

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -17,13 +17,18 @@ Always enabled.
 - `read_note(note_path)`: Read one note, with path checks and output limits.
 - `search_notes(query, folder, titles_only)`: Search titles or Markdown content.
 - `search_notes_by_date(date_from, date_to)`: Find recently modified notes.
-- `read_notes(paths)`: Batch-read notes with a response-size guard.
+- `read_notes(paths)`: Batch-read notes with a response-size guard. `paths` is
+  a list of vault-relative paths (one Pydantic argument, not `query=`).
 - `get_note_info(paths)`: Return metadata without full note content.
 - `list_templates()`: List available vault templates.
 - `get_frontmatter(note_path)`: Read YAML frontmatter.
 - `list_skills()`: List valid vault skills from `.agents/skills`.
 - `read_skill(name)`: Read a declared vault skill.
 - `get_global_rules()`: Read vault-level global agent rules.
+- `validate_note(content, title, mode)`: Lint a note against vault rules WITHOUT
+  writing it. Returns JSON `{valid, mode, violations[]}`. Call before
+  `create_note` / `patch_note` to skip a write round-trip. `mode` is
+  `create` (default), `edit`, or `append`.
 
 ## Optional Tool Sets
 
@@ -34,6 +39,11 @@ Optional tools are enabled from `.agents/vault.yaml` with
 
 - `suggest_note_location(title, content, tags)`: Suggest a vault folder.
 - `create_note(title, content, folder, tags, template, created_by)`: Create a note.
+  `tags` is a comma-separated string (e.g. `"astro, equipo"`); it is normalized
+  to a YAML list in the saved frontmatter. If `content` already starts with a
+  `---...---` frontmatter block, embedded fields (`type`, `status`, custom keys)
+  are preserved; conflicts with explicit parameters resolve in favour of the
+  embedded frontmatter.
 - `append_to_note(note_path, content, at_end)`: Append or prepend content.
 - `patch_note(note_path, operations)`: Apply atomic exact-match edits with
   operations shaped as `{"old": "...", "new": "..."}`. Compatibility aliases
@@ -93,3 +103,16 @@ project instead of embedding a second RAG stack inside this MCP server.
 - `obsidian://local_docs/{name}`: A declared local document.
 - `obsidian://integrations/obsidianrag/setup`: Guided ObsidianRAG setup playbook.
 - `obsidian://integrations/obsidianrag/config`: Safe ObsidianRAG integration config.
+
+## Naming Conventions
+
+Tool names follow two patterns by intent:
+
+- **Verb-first** for generic note operations: `create_note`, `read_note`,
+  `patch_note`, `move_note`, `delete_note`, `analyze_links`, `find_orphan_notes`.
+- **Namespace-prefixed** for domain-specific tool families: `canvas_*` (Obsidian
+  Canvas), `kanvas_*` (workflow boards), `rag_*` / `ask_vault` (semantic search).
+
+Renaming public tools is a breaking change for MCP clients, so the mix is
+intentional. When in doubt, search this reference first; the function-name
+prefix matches the tool name verbatim.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -56,7 +56,14 @@ Optional tools are enabled from `.agents/vault.yaml` with
 - `replace_note(note_path, content)`: Replace a full note.
 - `update_frontmatter(note_path, updates)`: Update YAML frontmatter.
 - `update_note_tags(note_path, tags)`: Update tag metadata.
-- `move_note(source, destination, create_folders)`: Move or rename a note.
+- `move_note(source, destination, create_folders, update_links)`: Move or
+  rename a note. When `update_links=True`, every vault wikilink targeting
+  the old stem is rewritten to the new stem (aliases/sections preserved).
+  When `False`, the response still reports how many references became
+  stale so you can re-run with `update_links=True`.
+- `rename_note(source, new_name, update_links=True)`: Rename a note in
+  place and update all wikilinks referencing it. Pass `new_name` as the
+  stem (without `.md`), or as a path to also move folders.
 - `delete_note(note_path, confirm)`: Delete a note after explicit confirmation.
 - `preview_replace_in_notes(...)`: Preview global replacements.
 - `apply_replace_in_notes(...)`: Apply global replacements.
@@ -74,6 +81,10 @@ Optional tools are enabled from `.agents/vault.yaml` with
 - `get_notes_by_tag(tag)`: Find notes with a tag.
 - `get_local_graph(note_path, depth)`: Explore local graph connections.
 - `find_orphan_notes()`: Find notes without incoming or outgoing links.
+- `find_broken_wikilinks(limit=100)`: List every `[[target]]` in the vault
+  whose target note doesn't exist. Returns source file + line + fuzzy
+  match suggestions per broken reference (Issue #6). Pair with `rename_note`
+  or `apply_replace_in_notes` to fix them in bulk.
 
 ### `obsidianrag`
 
@@ -98,6 +109,9 @@ project instead of embedding a second RAG stack inside this MCP server.
 
 ## Resources
 
+- `obsidian://docs/agent-quickstart`: AI-agent orientation (start here on
+  every new session). Two-call boot sequence, decision table mapping
+  intent -> tool, and common pitfalls.
 - `obsidian://capabilities`: Active prompts, tool sets, resources, and integrations.
 - `obsidian://profile`: Safe active profile summary.
 - `obsidian://skills/list`: Valid and invalid vault skills.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -8,30 +8,30 @@ contains local Spanish documentation.
 
 Always enabled.
 
-- `health_check()`: Validate the active vault and profile configuration.
-- `diagnose_vault_setup()`: Return actionable setup recommendations.
-- `list_client_roots()`: Inspect MCP client roots advertised through `roots/list`.
-- `route_task(request)`: Recommend prompts, skills, resources, and tools for a task.
-- `read_vault_context()`: Summarize folders, templates, common tags, and `.agents`.
-- `list_notes(folder, include_subfolders, limit, offset, pattern)`: List
+- `vault.health()`: Validate the active vault and profile configuration.
+- `vault.diagnose()`: Return actionable setup recommendations.
+- `client.roots()`: Inspect MCP client roots advertised through `roots/list`.
+- `route.task(request)`: Recommend prompts, skills, resources, and tools for a task.
+- `vault.context()`: Summarize folders, templates, common tags, and `.agents`.
+- `notes.list(folder, include_subfolders, limit, offset, pattern)`: List
   Markdown notes with pagination. Default `limit=500`; pass `limit=0` for
   no limit. Use `pattern` (glob like `"2026-*.md"`) to narrow further.
   Responses include a `Truncated:` footer with the next `offset` when more
   results exist.
-- `read_note(note_path)`: Read one note, with path checks and output limits.
-- `search_notes(query, folder, titles_only)`: Search titles or Markdown content.
-- `search_notes_by_date(date_from, date_to)`: Find recently modified notes.
-- `read_notes(paths)`: Batch-read notes with a response-size guard. `paths` is
+- `notes.read(note_path)`: Read one note, with path checks and output limits.
+- `notes.search(query, folder, titles_only)`: Search titles or Markdown content.
+- `notes.search_by_date(date_from, date_to)`: Find recently modified notes.
+- `notes.read_many(paths)`: Batch-read notes with a response-size guard. `paths` is
   a list of vault-relative paths (one Pydantic argument, not `query=`).
-- `get_note_info(paths)`: Return metadata without full note content.
-- `list_templates()`: List available vault templates.
-- `get_frontmatter(note_path)`: Read YAML frontmatter.
-- `list_skills()`: List valid vault skills from `.agents/skills`.
-- `read_skill(name)`: Read a declared vault skill.
-- `get_global_rules()`: Read vault-level global agent rules.
-- `validate_note(content, title, mode)`: Lint a note against vault rules WITHOUT
+- `notes.info(paths)`: Return metadata without full note content.
+- `templates.list()`: List available vault templates.
+- `notes.get_frontmatter(note_path)`: Read YAML frontmatter.
+- `skills.list()`: List valid vault skills from `.agents/skills`.
+- `skills.read(name)`: Read a declared vault skill.
+- `rules.get()`: Read vault-level global agent rules.
+- `notes.validate(content, title, mode)`: Lint a note against vault rules WITHOUT
   writing it. Returns JSON `{valid, mode, violations[]}`. Call before
-  `create_note` / `patch_note` to skip a write round-trip. `mode` is
+  `notes.create` / `notes.patch` to skip a write round-trip. `mode` is
   `create` (default), `edit`, or `append`.
 
 ## Optional Tool Sets
@@ -41,75 +41,75 @@ Optional tools are enabled from `.agents/vault.yaml` with
 
 ### `notes_write`
 
-- `suggest_note_location(title, content, tags)`: Suggest a vault folder.
-- `create_note(title, content, folder, tags, template, created_by)`: Create a note.
+- `notes.suggest_location(title, content, tags)`: Suggest a vault folder.
+- `notes.create(title, content, folder, tags, template, created_by)`: Create a note.
   `tags` is a comma-separated string (e.g. `"astro, equipo"`); it is normalized
   to a YAML list in the saved frontmatter. If `content` already starts with a
   `---...---` frontmatter block, embedded fields (`type`, `status`, custom keys)
   are preserved; conflicts with explicit parameters resolve in favour of the
   embedded frontmatter.
-- `append_to_note(note_path, content, at_end)`: Append or prepend content.
-- `patch_note(note_path, operations)`: Apply atomic exact-match edits with
+- `notes.append(note_path, content, at_end)`: Append or prepend content.
+- `notes.patch(note_path, operations)`: Apply atomic exact-match edits with
   operations shaped as `{"old": "...", "new": "..."}`. Compatibility aliases
   `oldText`/`newText` and `old_text`/`new_text` are accepted, but clients
   should prefer `old`/`new`.
-- `replace_note(note_path, content)`: Replace a full note.
-- `update_frontmatter(note_path, updates)`: Update YAML frontmatter.
-- `update_note_tags(note_path, tags)`: Update tag metadata.
-- `move_note(source, destination, create_folders, update_links)`: Move or
+- `notes.replace(note_path, content)`: Replace a full note.
+- `notes.update_frontmatter(note_path, updates)`: Update YAML frontmatter.
+- `notes.update_tags(note_path, tags)`: Update tag metadata.
+- `notes.move(source, destination, create_folders, update_links)`: Move or
   rename a note. When `update_links=True`, every vault wikilink targeting
   the old stem is rewritten to the new stem (aliases/sections preserved).
   When `False`, the response still reports how many references became
   stale so you can re-run with `update_links=True`.
-- `rename_note(source, new_name, update_links=True)`: Rename a note in
+- `notes.rename(source, new_name, update_links=True)`: Rename a note in
   place and update all wikilinks referencing it. Pass `new_name` as the
   stem (without `.md`), or as a path to also move folders.
-- `delete_note(note_path, confirm)`: Delete a note after explicit confirmation.
-- `preview_replace_in_notes(...)`: Preview global replacements.
-- `apply_replace_in_notes(...)`: Apply global replacements.
+- `notes.delete(note_path, confirm)`: Delete a note after explicit confirmation.
+- `notes.preview_replace(...)`: Preview global replacements.
+- `notes.apply_replace(...)`: Apply global replacements.
 
 ### `vault_analysis`
 
-- `get_vault_stats()`: Count notes, tags, links, and vault size.
-- `get_canonical_tags()`: Read the canonical tag registry.
-- `analyze_tags()`: Compare used tags against canonical tags.
-- `sync_tag_registry(update)`: Update tag registry statistics.
-- `list_tags()`: List tags currently used in the vault.
-- `analyze_links()`: Inspect internal link health.
-- `summarize_recent_activity(days)`: Summarize recent vault changes.
-- `get_backlinks(note_path)`: Find backlinks for a note.
-- `get_notes_by_tag(tag)`: Find notes with a tag.
-- `get_local_graph(note_path, depth)`: Explore local graph connections.
-- `find_orphan_notes()`: Find notes without incoming or outgoing links.
-- `lint_vault(folder, rule_ids, auto_fix, limit)`: Run vault rules across
+- `vault.stats()`: Count notes, tags, links, and vault size.
+- `tags.canonical()`: Read the canonical tag registry.
+- `tags.analyze()`: Compare used tags against canonical tags.
+- `tags.sync_registry(update)`: Update tag registry statistics.
+- `tags.list()`: List tags currently used in the vault.
+- `links.analyze()`: Inspect internal link health.
+- `activity.recent(days)`: Summarize recent vault changes.
+- `links.backlinks(note_path)`: Find backlinks for a note.
+- `tags.notes_with(tag)`: Find notes with a tag.
+- `links.local_graph(note_path, depth)`: Explore local graph connections.
+- `links.find_orphans()`: Find notes without incoming or outgoing links.
+- `vault.lint(folder, rule_ids, auto_fix, limit)`: Run vault rules across
   every note in one sweep (Issue #9). With `auto_fix=True` the
   regex-based heading/body rules are rewritten in place; frontmatter
   rules remain report-only because they need semantic input.
-- `find_broken_wikilinks(limit=100)`: List every `[[target]]` in the vault
+- `links.find_broken(limit=100)`: List every `[[target]]` in the vault
   whose target note doesn't exist. Returns source file + line + fuzzy
-  match suggestions per broken reference (Issue #6). Pair with `rename_note`
-  or `apply_replace_in_notes` to fix them in bulk.
+  match suggestions per broken reference (Issue #6). Pair with `notes.rename`
+  or `notes.apply_replace` to fix them in bulk.
 
 ### `obsidianrag`
 
 This pack delegates advanced semantic search to the external ObsidianRAG
 project instead of embedding a second RAG stack inside this MCP server.
 
-- `rag_setup_status()`: Diagnose the local ObsidianRAG setup.
-- `rag_health()`: Check whether the ObsidianRAG HTTP API is reachable.
-- `ask_vault(question, session_id)`: Ask a semantic question through ObsidianRAG.
-- `rebuild_rag_index()`: Trigger ObsidianRAG index rebuild.
+- `rag.setup_status()`: Diagnose the local ObsidianRAG setup.
+- `rag.health()`: Check whether the ObsidianRAG HTTP API is reachable.
+- `rag.ask(question, session_id)`: Ask a semantic question through ObsidianRAG.
+- `rag.rebuild_index()`: Trigger ObsidianRAG index rebuild.
 
 ### Other Packs
 
-- `agents_admin`: `refresh_skills_cache`, `create_skill`, `suggest_vault_skills`,
-  `sync_skills`.
-- `youtube`: `get_youtube_transcript`.
+- `agents_admin`: `skills.refresh_cache`, `skills.create`, `skills.suggest`,
+  `skills.sync`.
+- `youtube`: `youtube.transcript`.
 - `legacy_semantic`: deprecated in-process semantic tools, disabled by default.
   Prefer `obsidianrag` for all new semantic-search deployments.
 - `canvas`: Obsidian Canvas read/write tools.
 - `kanvas`: workflow/task-board tools.
-- `secundo_selebro`: personal profile tools such as `quick_capture`.
+- `secundo_selebro`: personal profile tools such as `inbox.capture`.
 
 ## Resources
 
@@ -130,10 +130,10 @@ project instead of embedding a second RAG stack inside this MCP server.
 
 Tool names follow two patterns by intent:
 
-- **Verb-first** for generic note operations: `create_note`, `read_note`,
-  `patch_note`, `move_note`, `delete_note`, `analyze_links`, `find_orphan_notes`.
+- **Verb-first** for generic note operations: `notes.create`, `notes.read`,
+  `notes.patch`, `notes.move`, `notes.delete`, `links.analyze`, `links.find_orphans`.
 - **Namespace-prefixed** for domain-specific tool families: `canvas_*` (Obsidian
-  Canvas), `kanvas_*` (workflow boards), `rag_*` / `ask_vault` (semantic search).
+  Canvas), `kanvas_*` (workflow boards), `rag_*` / `rag.ask` (semantic search).
 
 Renaming public tools is a breaking change for MCP clients, so the mix is
 intentional. When in doubt, search this reference first; the function-name

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -13,7 +13,11 @@ Always enabled.
 - `list_client_roots()`: Inspect MCP client roots advertised through `roots/list`.
 - `route_task(request)`: Recommend prompts, skills, resources, and tools for a task.
 - `read_vault_context()`: Summarize folders, templates, common tags, and `.agents`.
-- `list_notes(folder, include_subfolders)`: List Markdown notes.
+- `list_notes(folder, include_subfolders, limit, offset, pattern)`: List
+  Markdown notes with pagination. Default `limit=500`; pass `limit=0` for
+  no limit. Use `pattern` (glob like `"2026-*.md"`) to narrow further.
+  Responses include a `Truncated:` footer with the next `offset` when more
+  results exist.
 - `read_note(note_path)`: Read one note, with path checks and output limits.
 - `search_notes(query, folder, titles_only)`: Search titles or Markdown content.
 - `search_notes_by_date(date_from, date_to)`: Find recently modified notes.

--- a/obsidian_mcp/canvas/canvas_tools.py
+++ b/obsidian_mcp/canvas/canvas_tools.py
@@ -27,7 +27,7 @@ logger = get_logger(__name__)
 def register_canvas_tools(mcp: FastMCP) -> None:
     """Register generic canvas tools with the MCP server."""
 
-    @register_tool(mcp, "canvas_read")
+    @register_tool(mcp, "canvas.read")
     def canvas_read(canvas_path: str) -> str:
         """Read a canvas file and return a human-readable summary of its nodes, edges, and groups.
 
@@ -42,7 +42,7 @@ def register_canvas_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error reading canvas: {e}"
 
-    @register_tool(mcp, "canvas_list")
+    @register_tool(mcp, "canvas.list")
     def canvas_list(folder: str = "") -> str:
         """List all .canvas files in the vault or in a specific folder.
 
@@ -57,7 +57,7 @@ def register_canvas_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error listing canvases: {e}"
 
-    @register_tool(mcp, "canvas_add_card")
+    @register_tool(mcp, "canvas.add_card")
     def canvas_add_card(
         canvas_path: str,
         text: str,
@@ -84,7 +84,7 @@ def register_canvas_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error adding card: {e}"
 
-    @register_tool(mcp, "canvas_add_group")
+    @register_tool(mcp, "canvas.add_group")
     def canvas_add_group(canvas_path: str, label: str) -> str:
         """Create a new group/area in a canvas file.
 
@@ -100,7 +100,7 @@ def register_canvas_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error adding group: {e}"
 
-    @register_tool(mcp, "canvas_add_edge")
+    @register_tool(mcp, "canvas.add_edge")
     def canvas_add_edge(
         canvas_path: str,
         from_id: str,
@@ -123,7 +123,7 @@ def register_canvas_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error adding edge: {e}"
 
-    @register_tool(mcp, "canvas_update_card")
+    @register_tool(mcp, "canvas.update_card")
     def canvas_update_card(
         canvas_path: str,
         node_id: str,
@@ -146,7 +146,7 @@ def register_canvas_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error updating card: {e}"
 
-    @register_tool(mcp, "canvas_remove_card")
+    @register_tool(mcp, "canvas.remove_card")
     def canvas_remove_card(canvas_path: str, node_id: str) -> str:
         """Delete a card and all its connected edges from a canvas.
 
@@ -162,7 +162,7 @@ def register_canvas_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error removing card: {e}"
 
-    @register_tool(mcp, "canvas_remove_edge")
+    @register_tool(mcp, "canvas.remove_edge")
     def canvas_remove_edge(canvas_path: str, edge_id: str) -> str:
         """Delete a connection between two nodes.
 

--- a/obsidian_mcp/canvas/workflow_tools.py
+++ b/obsidian_mcp/canvas/workflow_tools.py
@@ -33,7 +33,7 @@ logger = get_logger(__name__)
 def register_workflow_tools(mcp: FastMCP) -> None:
     """Register kanvas workflow tools with the MCP server."""
 
-    @register_tool(mcp, "kanvas_status")
+    @register_tool(mcp, "kanvas.status")
     def kanvas_status(canvas_path: str) -> str:
         """Get a board overview: task counts by state, groups, total tasks.
 
@@ -48,7 +48,7 @@ def register_workflow_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error getting status: {e}"
 
-    @register_tool(mcp, "kanvas_task")
+    @register_tool(mcp, "kanvas.task")
     def kanvas_task(canvas_path: str, task_id: str) -> str:
         """Show details for a specific task: state, group, description, dependencies.
 
@@ -64,7 +64,7 @@ def register_workflow_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error showing task: {e}"
 
-    @register_tool(mcp, "kanvas_ready")
+    @register_tool(mcp, "kanvas.ready")
     def kanvas_ready(canvas_path: str) -> str:
         """List tasks that are ready to start (red/To Do with all dependencies met).
 
@@ -79,7 +79,7 @@ def register_workflow_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error getting ready tasks: {e}"
 
-    @register_tool(mcp, "kanvas_blocked")
+    @register_tool(mcp, "kanvas.blocked")
     def kanvas_blocked(canvas_path: str) -> str:
         """List tasks that are blocked and what is blocking them.
 
@@ -94,7 +94,7 @@ def register_workflow_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error getting blocked tasks: {e}"
 
-    @register_tool(mcp, "kanvas_start")
+    @register_tool(mcp, "kanvas.start")
     def kanvas_start(canvas_path: str, task_id: str) -> str:
         """Start a task: red (To Do) → orange (Doing). Validates dependencies are met.
 
@@ -110,7 +110,7 @@ def register_workflow_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error starting task: {e}"
 
-    @register_tool(mcp, "kanvas_finish")
+    @register_tool(mcp, "kanvas.finish")
     def kanvas_finish(canvas_path: str, task_id: str) -> str:
         """Finish a task: orange (Doing) → cyan (Review).
 
@@ -126,7 +126,7 @@ def register_workflow_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error finishing task: {e}"
 
-    @register_tool(mcp, "kanvas_pause")
+    @register_tool(mcp, "kanvas.pause")
     def kanvas_pause(canvas_path: str, task_id: str) -> str:
         """Pause a task: orange (Doing) → red (To Do).
 
@@ -142,7 +142,7 @@ def register_workflow_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error pausing task: {e}"
 
-    @register_tool(mcp, "kanvas_approve")
+    @register_tool(mcp, "kanvas.approve")
     def kanvas_approve(canvas_path: str, task_id: str) -> str:
         """Approve a proposed task: purple (Proposed) → red (To Do). RELAXED mode only.
 
@@ -158,7 +158,7 @@ def register_workflow_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error approving task: {e}"
 
-    @register_tool(mcp, "kanvas_complete")
+    @register_tool(mcp, "kanvas.complete")
     def kanvas_complete(canvas_path: str, task_id: str) -> str:
         """Mark a task as done: cyan (Review) → green (Done). RELAXED mode only.
 
@@ -174,7 +174,7 @@ def register_workflow_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error completing task: {e}"
 
-    @register_tool(mcp, "kanvas_edit_task")
+    @register_tool(mcp, "kanvas.edit_task")
     def kanvas_edit_task(canvas_path: str, task_id: str, text: str) -> str:
         """Update a task's description body. Task must be orange (or cyan in RELAXED mode).
 
@@ -191,7 +191,7 @@ def register_workflow_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error editing task: {e}"
 
-    @register_tool(mcp, "kanvas_add_dependency")
+    @register_tool(mcp, "kanvas.add_dependency")
     def kanvas_add_dependency(canvas_path: str, from_task: str, to_task: str) -> str:
         """Add a dependency: from_task blocks to_task. Rejects cycles.
 
@@ -208,7 +208,7 @@ def register_workflow_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error adding dependency: {e}"
 
-    @register_tool(mcp, "kanvas_propose_task")
+    @register_tool(mcp, "kanvas.propose_task")
     def kanvas_propose_task(
         canvas_path: str,
         group: str,
@@ -235,7 +235,7 @@ def register_workflow_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error proposing task: {e}"
 
-    @register_tool(mcp, "kanvas_propose_group")
+    @register_tool(mcp, "kanvas.propose_group")
     def kanvas_propose_group(canvas_path: str, label: str) -> str:
         """Add a new group/phase to the project canvas.
 
@@ -251,7 +251,7 @@ def register_workflow_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error proposing group: {e}"
 
-    @register_tool(mcp, "kanvas_init")
+    @register_tool(mcp, "kanvas.init")
     def kanvas_init(
         canvas_path: str,
         groups: list[str],

--- a/obsidian_mcp/messages.py
+++ b/obsidian_mcp/messages.py
@@ -41,8 +41,13 @@ class ErrorMessages:
     SEMANTIC_NOT_AVAILABLE: str = "Servicio semantico no disponible."
     TIMEOUT: str = "Operacion excedio el tiempo limite ({seconds}s)."
 
-    # Confirmation flow
-    OPERATION_CANCELLED: str = "Operacion cancelada por el usuario."
+    # Confirmation flow (Issue #1: surface specific reason, not opaque "cancelled")
+    OPERATION_DECLINED: str = (
+        "Operacion cancelada: el usuario rechazo explicitamente la confirmacion."
+    )
+    OPERATION_DISMISSED: str = (
+        "Operacion cancelada: el usuario cerro la confirmacion sin responder."
+    )
     OPERATION_CANCELLED_NO_CONFIRM: str = (
         "Operacion cancelada: este cliente no soporta confirmacion interactiva. "
         "Usa un cliente compatible con elicit() o invoca preview_replace_in_notes primero."

--- a/obsidian_mcp/messages.py
+++ b/obsidian_mcp/messages.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
+# pylint: disable=invalid-name,too-many-instance-attributes
 class ErrorMessages:
     """Standardized error messages for MCP tools."""
 
@@ -40,8 +41,16 @@ class ErrorMessages:
     SEMANTIC_NOT_AVAILABLE: str = "Servicio semantico no disponible."
     TIMEOUT: str = "Operacion excedio el tiempo limite ({seconds}s)."
 
+    # Confirmation flow
+    OPERATION_CANCELLED: str = "Operacion cancelada por el usuario."
+    OPERATION_CANCELLED_NO_CONFIRM: str = (
+        "Operacion cancelada: este cliente no soporta confirmacion interactiva. "
+        "Usa un cliente compatible con elicit() o invoca preview_replace_in_notes primero."
+    )
+
 
 @dataclass(frozen=True)
+# pylint: disable=invalid-name,too-many-instance-attributes
 class SuccessMessages:
     """Standardized success messages for MCP tools."""
 

--- a/obsidian_mcp/middleware.py
+++ b/obsidian_mcp/middleware.py
@@ -97,14 +97,39 @@ def run_validations(
     frontmatter: dict[str, Any] | None = None,
 ) -> list[str]:
     """Run applicable validations and return list of warning strings."""
-    warnings = []
+    return [
+        warning
+        for _, warning in iter_violations(
+            rules, mode, title=title, content=content, frontmatter=frontmatter
+        )
+    ]
+
+
+def iter_violations(
+    rules: list[dict[str, Any]],
+    mode: str | None,
+    *,
+    title: str = "",
+    content: str = "",
+    frontmatter: dict[str, Any] | None = None,
+) -> list[tuple[dict[str, Any], str]]:
+    """Like ``run_validations`` but also returns the rule that fired.
+
+    Public surface used by ``lint_vault`` (Issue #9) to decide which
+    violations are auto-fixable per-rule.
+
+    Pass ``mode=None`` to ignore each rule's ``applies_to`` filter --
+    useful for whole-vault lint sweeps where every rule should be
+    enforced regardless of write mode.
+    """
+    pairs: list[tuple[dict[str, Any], str]] = []
     for rule in rules:
-        if mode not in rule.get("applies_to", []):
+        if mode is not None and mode not in rule.get("applies_to", []):
             continue
         warning = _check_rule(rule, title, content, frontmatter or {})
         if warning:
-            warnings.append(warning)
-    return warnings
+            pairs.append((rule, warning))
+    return pairs
 
 
 def _check_rule(
@@ -164,6 +189,66 @@ def _check_allowed_values(rule: dict[str, Any], fm: dict[str, Any]) -> str | Non
     if value and value not in rule["allowed_values"]:
         return rule["warning"].format(value=value)
     return None
+
+
+# --- Auto-fix Engine (Issue #9) ---
+
+
+def is_rule_autofixable(rule: dict[str, Any]) -> bool:
+    """Return True iff ``rule`` is one of the kinds ``apply_autofix`` handles.
+
+    Currently: regex-based ``scope=headings`` or ``scope=body`` rules with a
+    ``pattern``. These map cleanly to ``re.sub(pattern, "", ...)``.
+
+    Frontmatter rules (``required_fields``, ``allowed_values``) need
+    semantic user input and are intentionally NOT auto-fixed.
+    """
+    if "pattern" not in rule:
+        return False
+    return rule.get("scope") in {"headings", "body"}
+
+
+def apply_autofix(rule: dict[str, Any], content: str) -> tuple[str, int]:
+    """Apply ``rule`` as an in-place rewrite of ``content``.
+
+    For ``scope=headings``: strip every match of ``rule['pattern']`` from
+    lines that start with ``#`` (after lstrip). For ``scope=body``: strip
+    every match anywhere. Whitespace collapse is applied to keep
+    headings readable after emoji removal.
+
+    Returns ``(new_content, replacement_count)``. Counts pattern hits,
+    not lines touched.
+    """
+    if not is_rule_autofixable(rule):
+        return content, 0
+
+    try:
+        pattern = re.compile(rule["pattern"])
+    except re.error:
+        return content, 0
+
+    scope = rule["scope"]
+    count = 0
+
+    if scope == "headings":
+        new_lines: list[str] = []
+        for line in content.splitlines(keepends=True):
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                new_line, n = pattern.subn("", line)
+                if n:
+                    count += n
+                    # Collapse "## " + emoji + " title" -> "## title"
+                    new_line = re.sub(r"^(#+)\s+\s+", r"\1 ", new_line)
+                    new_line = re.sub(r"^(#+)\s+$", r"\1", new_line)
+                new_lines.append(new_line)
+            else:
+                new_lines.append(line)
+        return "".join(new_lines), count
+
+    # scope == "body"
+    new_content, count = pattern.subn("", content)
+    return new_content, count
 
 
 # --- Response Enrichment ---

--- a/obsidian_mcp/middleware.py
+++ b/obsidian_mcp/middleware.py
@@ -115,7 +115,7 @@ def iter_violations(
 ) -> list[tuple[dict[str, Any], str]]:
     """Like ``run_validations`` but also returns the rule that fired.
 
-    Public surface used by ``lint_vault`` (Issue #9) to decide which
+    Public surface used by ``vault.lint`` (Issue #9) to decide which
     violations are auto-fixable per-rule.
 
     Pass ``mode=None`` to ignore each rule's ``applies_to`` filter --
@@ -253,15 +253,15 @@ def apply_autofix(rule: dict[str, Any], content: str) -> tuple[str, int]:
 
 # --- Response Enrichment ---
 
-CONTENT_CREATION_TOOLS = frozenset({"create_note", "append_to_note"})
+CONTENT_CREATION_TOOLS = frozenset({"notes.create", "notes.append"})
 
 TOOL_MODE_MAP: dict[str, str] = {
-    "create_note": "create",
-    "quick_capture": "create",
-    "append_to_note": "append",
-    "patch_note": "edit",
-    "replace_note": "edit",
-    "update_frontmatter": "edit",
+    "notes.create": "create",
+    "inbox.capture": "create",
+    "notes.append": "append",
+    "notes.patch": "edit",
+    "notes.replace": "edit",
+    "notes.update_frontmatter": "edit",
 }
 
 

--- a/obsidian_mcp/middleware.py
+++ b/obsidian_mcp/middleware.py
@@ -203,11 +203,16 @@ def enrich_response(
         for w in warnings:
             parts.append(f"- {w}")
 
-    if tool_name in CONTENT_CREATION_TOOLS:
-        prose = load_vault_rules_prose()
-        if prose:
-            parts.append("---")
-            parts.append("[REGLAS ACTIVAS DEL VAULT]")
-            parts.append(prose)
+        if tool_name in CONTENT_CREATION_TOOLS:
+            prose = load_vault_rules_prose()
+            if prose:
+                parts.append("---")
+                parts.append("[REGLAS ACTIVAS DEL VAULT]")
+                parts.append(prose)
+    elif tool_name in CONTENT_CREATION_TOOLS:
+        parts.append("---")
+        parts.append(
+            "[Reglas del vault activas. Llama a get_global_rules() si necesitas el texto completo.]"
+        )
 
     return "\n".join(parts)

--- a/obsidian_mcp/prompts/core.py
+++ b/obsidian_mcp/prompts/core.py
@@ -37,13 +37,13 @@ def register_core_prompts(mcp: FastMCP) -> None:
         You are an Obsidian assistant for the vault "{vault_name}".
 
         Before writing or making complex changes:
-        1. Read global rules with `get_global_rules()`.
-        2. Check available skills with `list_skills()`.
+        1. Read global rules with `rules.get()`.
+        2. Check available skills with `skills.list()`.
         3. If a skill matches the task, read it with
-           `read_skill("skill-name")`.
-        4. Read vault context with `read_vault_context()`.
-        5. When creating notes, prefer real templates from `list_templates()`
-           and `read_note()`.
+           `skills.read("skill-name")`.
+        4. Read vault context with `vault.context()`.
+        5. When creating notes, prefer real templates from `templates.list()`
+           and `notes.read()`.
 
         Reuse existing tags and conventions. Do not invent a structure when
         the vault already has a matching template, standard, or skill.
@@ -65,10 +65,10 @@ def register_core_prompts(mcp: FastMCP) -> None:
         Desired note type: "{note_type}".
 
         Required flow:
-        1. Read global rules with `get_global_rules()`.
-        2. List real templates with `list_templates()`.
-        3. Read the best matching template with `read_note()`.
-        4. Use `suggest_note_location()` to choose the destination.
+        1. Read global rules with `rules.get()`.
+        2. List real templates with `templates.list()`.
+        3. Read the best matching template with `notes.read()`.
+        4. Use `notes.suggest_location()` to choose the destination.
         5. Create the note without inventing frontmatter fields that conflict
            with the template or vault conventions.
 
@@ -88,9 +88,9 @@ def register_core_prompts(mcp: FastMCP) -> None:
         The user needs a vault template for: "{template_goal}".
 
         Required flow:
-        1. Run `list_templates()`.
+        1. Run `templates.list()`.
         2. Choose the closest template by purpose, not just filename.
-        3. Read the template with `read_note()`.
+        3. Read the template with `notes.read()`.
         4. Explain which template you chose and why.
         5. Use the template exactly as the structural base for any new note.
         """
@@ -107,9 +107,9 @@ def register_core_prompts(mcp: FastMCP) -> None:
         Explore the vault context for: "{query}".
 
         Required flow:
-        1. Read global rules with `get_global_rules()`.
-        2. Search notes with `search_notes()`.
-        3. Read the most relevant notes with `read_note()`.
+        1. Read global rules with `rules.get()`.
+        2. Search notes with `notes.search()`.
+        3. Read the most relevant notes with `notes.read()`.
         4. Use backlinks or graph tools when relationships matter.
         5. Summarize what you found before proposing edits.
 

--- a/obsidian_mcp/resources/profile.py
+++ b/obsidian_mcp/resources/profile.py
@@ -67,14 +67,14 @@ def register_profile_resources(mcp: FastMCP) -> None:
                 "obsidian://local_docs/{name}",
             ],
             "diagnostics": [
-                "health_check",
-                "diagnose_vault_setup",
-                "list_client_roots",
-                "route_task",
+                "vault.health",
+                "vault.diagnose",
+                "client.roots",
+                "route.task",
             ],
             "client_capabilities": {
                 "roots": {
-                    "tool": "list_client_roots",
+                    "tool": "client.roots",
                     "purpose": (
                         "Inspect roots advertised by the MCP client so agents can "
                         "confirm workspace/vault access before setup work."
@@ -82,7 +82,7 @@ def register_profile_resources(mcp: FastMCP) -> None:
                 }
             },
             "obsidianrag_tools": (
-                ["rag_setup_status", "rag_health", "ask_vault", "rebuild_rag_index"]
+                ["rag.setup_status", "rag.health", "rag.ask", "rag.rebuild_index"]
                 if _is_tool_set_enabled("obsidianrag")
                 else []
             ),
@@ -217,9 +217,9 @@ def register_profile_resources(mcp: FastMCP) -> None:
         """Return the AI-agent orientation doc (Issue #4).
 
         Tells the agent the two-call boot sequence
-        (``read_vault_context`` -> ``get_global_rules``), provides a
+        (``vault.context`` -> ``rules.get``), provides a
         decision table mapping intents to tools, and lists common
-        traps (e.g. ``read_notes`` uses ``paths`` not ``query``).
+        traps (e.g. ``notes.read_many`` uses ``paths`` not ``query``).
         """
         doc_path = Path(__file__).resolve().parents[2] / "docs" / "agent-quickstart.md"
         if not doc_path.exists():

--- a/obsidian_mcp/resources/profile.py
+++ b/obsidian_mcp/resources/profile.py
@@ -212,6 +212,20 @@ def register_profile_resources(mcp: FastMCP) -> None:
             vault_path, config.profile.local_docs[name], "Local doc"
         )
 
+    @mcp.resource("obsidian://docs/agent-quickstart")
+    def agent_quickstart_resource() -> str:
+        """Return the AI-agent orientation doc (Issue #4).
+
+        Tells the agent the two-call boot sequence
+        (``read_vault_context`` -> ``get_global_rules``), provides a
+        decision table mapping intents to tools, and lists common
+        traps (e.g. ``read_notes`` uses ``paths`` not ``query``).
+        """
+        doc_path = Path(__file__).resolve().parents[2] / "docs" / "agent-quickstart.md"
+        if not doc_path.exists():
+            return "❌ Error: agent-quickstart.md was not bundled with this install."
+        return doc_path.read_text(encoding="utf-8")
+
     if _is_tool_set_enabled("obsidianrag"):
 
         @mcp.resource("obsidian://integrations/obsidianrag/setup")

--- a/obsidian_mcp/tools/agents.py
+++ b/obsidian_mcp/tools/agents.py
@@ -22,22 +22,22 @@ from .registry import register_tool
 def register_agent_tools(mcp: FastMCP) -> None:
     """Register vault skill tools and resources."""
 
-    @register_tool(mcp, "list_skills")
+    @register_tool(mcp, "skills.list")
     def list_skills() -> str:
         """List skills available in the vault."""
         return list_available_skills().to_display()
 
-    @register_tool(mcp, "read_skill")
+    @register_tool(mcp, "skills.read")
     def read_skill(name: str) -> str:
         """Read a specific vault skill file."""
         return get_agent_instructions(name).to_display()
 
-    @register_tool(mcp, "get_global_rules")
+    @register_tool(mcp, "rules.get")
     def get_global_rules() -> str:
         """Read global vault agent rules."""
         return get_global_rules_logic().to_display()
 
-    @register_tool(mcp, "validate_note")
+    @register_tool(mcp, "notes.validate")
     def validate_note(
         content: str,
         title: str = "",
@@ -55,12 +55,12 @@ def register_agent_tools(mcp: FastMCP) -> None:
         """
         return validate_note_logic(title=title, content=content, mode=mode).to_display()
 
-    @register_tool(mcp, "refresh_skills_cache")
+    @register_tool(mcp, "skills.refresh_cache")
     def refresh_skills_cache() -> str:
         """Invalidate and refresh the in-memory skill cache."""
         return refresh_skills_cache_logic().to_display()
 
-    @register_tool(mcp, "create_skill")
+    @register_tool(mcp, "skills.create")
     def create_skill(
         name: str,
         description: str,
@@ -77,12 +77,12 @@ def register_agent_tools(mcp: FastMCP) -> None:
             default_location,
         ).to_display()
 
-    @register_tool(mcp, "suggest_vault_skills")
+    @register_tool(mcp, "skills.suggest")
     def suggest_vault_skills() -> str:
         """Analyze the vault and suggest useful personal skills."""
         return suggest_skills_for_vault().to_display()
 
-    @register_tool(mcp, "sync_skills")
+    @register_tool(mcp, "skills.sync")
     def sync_vault_skills(update: bool = False) -> str:
         """Validate skills and optionally apply automatic fixes."""
         return sync_skills(update).to_display()

--- a/obsidian_mcp/tools/agents.py
+++ b/obsidian_mcp/tools/agents.py
@@ -8,6 +8,7 @@ from .agents_generator import generate_skill, suggest_skills_for_vault, sync_ski
 from .agents_logic import (
     get_agent_instructions,
     list_available_skills,
+    validate_note_logic,
 )
 from .agents_logic import (
     get_global_rules as get_global_rules_logic,
@@ -35,6 +36,24 @@ def register_agent_tools(mcp: FastMCP) -> None:
     def get_global_rules() -> str:
         """Read global vault agent rules."""
         return get_global_rules_logic().to_display()
+
+    @register_tool(mcp, "validate_note")
+    def validate_note(
+        content: str,
+        title: str = "",
+        mode: str = "create",
+    ) -> str:
+        """Lint a note against vault rules without writing it.
+
+        Use BEFORE create_note / patch_note to surface frontmatter, heading,
+        and tag violations in-context. Cheaper than round-tripping a write.
+
+        Args:
+            content: Full note body (YAML frontmatter optional but recommended).
+            title: Optional note title for rules with scope='title'.
+            mode: 'create' (default), 'edit', or 'append'.
+        """
+        return validate_note_logic(title=title, content=content, mode=mode).to_display()
 
     @register_tool(mcp, "refresh_skills_cache")
     def refresh_skills_cache() -> str:

--- a/obsidian_mcp/tools/agents_generator.py
+++ b/obsidian_mcp/tools/agents_generator.py
@@ -43,11 +43,11 @@ SKILL_TEMPLATE = dedent("""
     {instructions}
 
     ## PATCH NOTE GOLDEN RULE
-    When using `patch_note`, send exact old->new operations:
-    - Read the note first with `read_note`.
+    When using `notes.patch`, send exact old->new operations:
+    - Read the note first with `notes.read`.
     - `old` must be exact text from the note, including line breaks.
     - `old` must be unique. If it appears more than once, include more context.
-    - Use `replace_note` for full-note replacement.
+    - Use `notes.replace` for full-note replacement.
 """).strip()
 
 
@@ -87,7 +87,7 @@ def generate_skill(
     if skill_file.exists():
         return Result.fail(
             f"A skill named '{nombre_limpio}' already exists. "
-            "Use `patch_note` to modify it."
+            "Use `notes.patch` to modify it."
         )
 
     # Prepare template values
@@ -127,7 +127,7 @@ def generate_skill(
     return Result.ok(
         f"Skill creada: **{titulo}**\n"
         f"Location: `.agents/skills/{nombre_limpio}/SKILL.md`\n\n"
-        "The skill is now available. Use `list_skills()` to see it."
+        "The skill is now available. Use `skills.list()` to see it."
     )
 
 
@@ -367,11 +367,11 @@ def sync_skills(actualizar: bool = False) -> Result[str]:
                 golden_rule = dedent("""
 
                     ## PATCH NOTE GOLDEN RULE
-                    When using `patch_note`, send exact old->new operations:
-                    - Read the note first with `read_note`.
+                    When using `notes.patch`, send exact old->new operations:
+                    - Read the note first with `notes.read`.
                     - `old` must be exact text from the note.
                     - `old` must be unique. If it appears more than once, include more context.
-                    - Use `replace_note` for full-note replacement.
+                    - Use `notes.replace` for full-note replacement.
                 """).strip()
                 skill_file.write_text(content + "\n\n" + golden_rule, encoding="utf-8")
                 if skill_dir.name not in fixed:
@@ -390,6 +390,6 @@ def sync_skills(actualizar: bool = False) -> Result[str]:
     if actualizar and fixed:
         output += f"\n✅ Corregidas: {', '.join(fixed)}"
     elif not actualizar and any(i.get("fixable") for i in issues):
-        output += "\nRun `sync_skills(update=True)` to apply fixes."
+        output += "\nRun `skills.sync(update=True)` to apply fixes."
 
     return Result.ok(output)

--- a/obsidian_mcp/tools/agents_logic.py
+++ b/obsidian_mcp/tools/agents_logic.py
@@ -244,3 +244,49 @@ def refresh_skills_cache() -> Result[str]:
     return Result.ok(
         "✅ Caché de skills invalidado. La próxima consulta recargará las skills."
     )
+
+
+def validate_note_logic(
+    title: str = "",
+    content: str = "",
+    mode: str = "create",
+) -> Result[str]:
+    """Run vault rules against arbitrary content without writing.
+
+    Lets agents lint a note before calling create_note / patch_note so they
+    can fix violations in-context instead of round-tripping through a write.
+
+    Args:
+        title: Note title (used by rules with scope='title').
+        content: Full note body, optionally including YAML frontmatter.
+        mode: One of 'create', 'edit', 'append'. Determines which rules apply.
+
+    Returns:
+        Result with a JSON summary {valid, mode, violations[]}.
+    """
+    import json
+
+    from ..middleware import load_vault_rules, run_validations
+    from .creation_logic import _extract_frontmatter_from_content
+
+    if mode not in {"create", "edit", "append"}:
+        return Result.fail(
+            f"mode debe ser uno de: create, edit, append (recibido: '{mode}')."
+        )
+
+    frontmatter, body = _extract_frontmatter_from_content(content)
+    rules = load_vault_rules()
+    warnings = run_validations(
+        rules,
+        mode=mode,
+        title=title,
+        content=body if frontmatter else content,
+        frontmatter=frontmatter,
+    )
+
+    payload: dict[str, Any] = {
+        "valid": not warnings,
+        "mode": mode,
+        "violations": warnings,
+    }
+    return Result.ok(json.dumps(payload, ensure_ascii=False, indent=2))

--- a/obsidian_mcp/tools/analysis.py
+++ b/obsidian_mcp/tools/analysis.py
@@ -9,6 +9,9 @@ from .analysis_logic import (
     analyze_tags as analyze_tags_logic,
 )
 from .analysis_logic import (
+    find_broken_wikilinks as find_broken_wikilinks_logic,
+)
+from .analysis_logic import (
     get_canonical_tags as get_canonical_tags_logic,
 )
 from .analysis_logic import (
@@ -69,11 +72,33 @@ def register_analysis_tools(mcp: FastMCP) -> None:
 
     @register_tool(mcp, "analyze_links")
     def analyze_links() -> str:
-        """Analyze internal links in the vault."""
+        """Analyze internal links in the vault.
+
+        High-level overview (counts of broken/valid/most-referenced).
+        For per-link broken-with-suggestions output, use
+        ``find_broken_wikilinks`` instead.
+        """
         try:
             return analyze_links_logic().to_display()
         except (OSError, ValueError) as e:
             return f"Error analyzing links: {e}"
+
+    @register_tool(mcp, "find_broken_wikilinks")
+    def find_broken_wikilinks(limit: int = 100) -> str:
+        """Find every wikilink in the vault whose target note doesn't exist.
+
+        Issue #6: returns source-file + line + fuzzy suggestions for each
+        broken ``[[target]]`` reference, so renames and typos can be
+        fixed without manual grepping.
+
+        Args:
+            limit: Max number of broken links in the response (default 100).
+                0 = no limit.
+        """
+        try:
+            return find_broken_wikilinks_logic(limit=limit).to_display()
+        except (OSError, ValueError) as e:
+            return f"Error finding broken wikilinks: {e}"
 
     @register_tool(mcp, "summarize_recent_activity")
     def summarize_recent_activity(days: int = 7) -> str:

--- a/obsidian_mcp/tools/analysis.py
+++ b/obsidian_mcp/tools/analysis.py
@@ -33,7 +33,7 @@ from .registry import register_tool
 def register_analysis_tools(mcp: FastMCP) -> None:
     """Register vault analysis tools."""
 
-    @register_tool(mcp, "get_vault_stats")
+    @register_tool(mcp, "vault.stats")
     def get_vault_stats() -> str:
         """Generate vault statistics."""
         try:
@@ -41,7 +41,7 @@ def register_analysis_tools(mcp: FastMCP) -> None:
         except (OSError, ValueError) as e:
             return f"Error generating vault stats: {e}"
 
-    @register_tool(mcp, "get_canonical_tags")
+    @register_tool(mcp, "tags.canonical")
     def get_canonical_tags() -> str:
         """Read the canonical tag registry."""
         try:
@@ -49,7 +49,7 @@ def register_analysis_tools(mcp: FastMCP) -> None:
         except (OSError, ValueError) as e:
             return f"Error reading canonical tags: {e}"
 
-    @register_tool(mcp, "analyze_tags")
+    @register_tool(mcp, "tags.analyze")
     def analyze_tags() -> str:
         """Analyze tag usage in the vault."""
         try:
@@ -57,7 +57,7 @@ def register_analysis_tools(mcp: FastMCP) -> None:
         except (OSError, ValueError) as e:
             return f"Error analyzing tags: {e}"
 
-    @register_tool(mcp, "sync_tag_registry")
+    @register_tool(mcp, "tags.sync_registry")
     def sync_tag_registry(update: bool = False) -> str:
         """Sync vault tag usage with the canonical tag registry."""
         try:
@@ -65,7 +65,7 @@ def register_analysis_tools(mcp: FastMCP) -> None:
         except (OSError, ValueError) as e:
             return f"Error syncing tag registry: {e}"
 
-    @register_tool(mcp, "list_tags")
+    @register_tool(mcp, "tags.list")
     def list_tags() -> str:
         """List all tags currently used in the vault."""
         try:
@@ -73,20 +73,20 @@ def register_analysis_tools(mcp: FastMCP) -> None:
         except (OSError, ValueError) as e:
             return f"Error listing tags: {e}"
 
-    @register_tool(mcp, "analyze_links")
+    @register_tool(mcp, "links.analyze")
     def analyze_links() -> str:
         """Analyze internal links in the vault.
 
         High-level overview (counts of broken/valid/most-referenced).
         For per-link broken-with-suggestions output, use
-        ``find_broken_wikilinks`` instead.
+        ``links.find_broken`` instead.
         """
         try:
             return analyze_links_logic().to_display()
         except (OSError, ValueError) as e:
             return f"Error analyzing links: {e}"
 
-    @register_tool(mcp, "lint_vault")
+    @register_tool(mcp, "vault.lint")
     def lint_vault(
         folder: str = "",
         rule_ids: str = "",
@@ -118,7 +118,7 @@ def register_analysis_tools(mcp: FastMCP) -> None:
         except (OSError, ValueError) as e:
             return f"Error linting vault: {e}"
 
-    @register_tool(mcp, "find_broken_wikilinks")
+    @register_tool(mcp, "links.find_broken")
     def find_broken_wikilinks(limit: int = 100) -> str:
         """Find every wikilink in the vault whose target note doesn't exist.
 
@@ -135,7 +135,7 @@ def register_analysis_tools(mcp: FastMCP) -> None:
         except (OSError, ValueError) as e:
             return f"Error finding broken wikilinks: {e}"
 
-    @register_tool(mcp, "summarize_recent_activity")
+    @register_tool(mcp, "activity.recent")
     def summarize_recent_activity(days: int = 7) -> str:
         """Summarize recent vault activity."""
         try:

--- a/obsidian_mcp/tools/analysis.py
+++ b/obsidian_mcp/tools/analysis.py
@@ -22,6 +22,9 @@ from .analysis_logic import (
     get_vault_stats as get_vault_stats_logic,
 )
 from .analysis_logic import (
+    lint_vault as lint_vault_logic,
+)
+from .analysis_logic import (
     sync_tag_registry as sync_tag_registry_logic,
 )
 from .registry import register_tool
@@ -82,6 +85,38 @@ def register_analysis_tools(mcp: FastMCP) -> None:
             return analyze_links_logic().to_display()
         except (OSError, ValueError) as e:
             return f"Error analyzing links: {e}"
+
+    @register_tool(mcp, "lint_vault")
+    def lint_vault(
+        folder: str = "",
+        rule_ids: str = "",
+        auto_fix: bool = False,
+        limit: int = 200,
+    ) -> str:
+        """Run vault rules across every note and report violations.
+
+        Single sweep that replaces per-note patches (Issue #9). With
+        ``auto_fix=True`` the regex-based heading/body rules are
+        applied in place; frontmatter rules remain report-only since
+        they need user input.
+
+        Args:
+            folder: Restrict scan to a vault-relative folder.
+            rule_ids: Comma-separated rule IDs to run (empty = all).
+            auto_fix: When True, write fixes to disk for auto-fixable
+                rules. Default False -> dry run.
+            limit: Max violations in the response (default 200).
+        """
+        try:
+            ids = [r.strip() for r in rule_ids.split(",") if r.strip()] or None
+            return lint_vault_logic(
+                folder=folder,
+                rule_ids=ids,
+                auto_fix=auto_fix,
+                limit=limit,
+            ).to_display()
+        except (OSError, ValueError) as e:
+            return f"Error linting vault: {e}"
 
     @register_tool(mcp, "find_broken_wikilinks")
     def find_broken_wikilinks(limit: int = 100) -> str:

--- a/obsidian_mcp/tools/analysis_logic.py
+++ b/obsidian_mcp/tools/analysis_logic.py
@@ -458,6 +458,148 @@ def analyze_links() -> Result[str]:
     return Result.ok(resultado)
 
 
+def lint_vault(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    folder: str = "",
+    rule_ids: list[str] | None = None,
+    auto_fix: bool = False,
+    limit: int = 200,
+) -> Result[str]:
+    """Run vault-rule validations across every note (Issue #9).
+
+    Replaces the per-note + manual-fix dance the 2026-05-17 session
+    described (60 individual patch_note calls to strip emojis from
+    headings) with a single sweep.
+
+    Args:
+        folder: Restrict to a vault-relative folder (empty = whole vault).
+        rule_ids: Limit to specific rule IDs (e.g. ``["no_emoji_headings"]``).
+            Empty/None = every rule loaded from REGLAS_GLOBALES.md.
+        auto_fix: When True, apply fixes for auto-fixable rules
+            (regex-based scope=headings or scope=body) and write the
+            results back to disk. Frontmatter rules are always
+            report-only.
+        limit: Cap on violations reported in the response.
+
+    Returns:
+        Result with a per-file breakdown of violations and, when
+        ``auto_fix`` is True, a summary of how many notes were fixed.
+    """
+    from ..middleware import (
+        apply_autofix,
+        is_rule_autofixable,
+        iter_violations,
+        load_vault_rules,
+    )
+    from ..utils import is_path_forbidden
+    from .creation_logic import _extract_frontmatter_from_content
+
+    vault_path = get_vault_path()
+    if not vault_path:
+        return Result.fail("La ruta del vault no está configurada.")
+
+    if limit < 0:
+        return Result.fail("limit debe ser >= 0.")
+
+    if folder:
+        scan_root = vault_path / folder
+        if not scan_root.exists():
+            return Result.fail(f"Carpeta no existe: {folder}")
+    else:
+        scan_root = vault_path
+
+    rules = load_vault_rules()
+    if rule_ids:
+        wanted = set(rule_ids)
+        rules = [r for r in rules if r.get("id") in wanted]
+        if not rules:
+            return Result.fail(
+                f"Ningun rule_id de {sorted(wanted)} esta definido en REGLAS_GLOBALES.md."
+            )
+
+    violations_by_file: dict[str, list[str]] = {}
+    fixed_by_file: dict[str, int] = {}
+    total_violations = 0
+    files_scanned = 0
+
+    for md_file in scan_root.rglob("*.md"):
+        # Skip restricted/system folders (.agents, .obsidian, .trash, etc.).
+        forbidden, _ = is_path_forbidden(md_file, vault_path)
+        if forbidden:
+            continue
+        # Also skip the rules file itself.
+        if md_file.name == "REGLAS_GLOBALES.md":
+            continue
+
+        files_scanned += 1
+        try:
+            content = md_file.read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        frontmatter, body = _extract_frontmatter_from_content(content)
+        title = md_file.stem
+        rel = str(md_file.relative_to(vault_path))
+
+        # mode='edit' covers post-creation linting; frontmatter rules
+        # that only apply at 'create' time are skipped by design.
+        violations = iter_violations(
+            rules,
+            mode=None,  # whole-vault sweep: every rule applies
+            title=title,
+            content=body,
+            frontmatter=frontmatter or {},
+        )
+        for rule, warning in violations:
+            total_violations += 1
+            label = f"[{rule.get('id', '?')}] {warning}"
+            violations_by_file.setdefault(rel, []).append(label)
+
+            if auto_fix and is_rule_autofixable(rule):
+                new_content, n = apply_autofix(rule, content)
+                if n:
+                    md_file.write_text(new_content, encoding="utf-8")
+                    fixed_by_file[rel] = fixed_by_file.get(rel, 0) + n
+                    content = new_content  # refresh for any further rules
+                    _, body = _extract_frontmatter_from_content(content)
+
+    if total_violations == 0:
+        return Result.ok(
+            f"OK: 0 violaciones en {files_scanned} notas escaneadas"
+            f"{' (filtro: ' + folder + ')' if folder else ''}."
+        )
+
+    lines: list[str] = [
+        (
+            f"Lint vault: {total_violations} violacion(es) en "
+            f"{len(violations_by_file)} de {files_scanned} notas."
+        ),
+        "",
+    ]
+    if auto_fix:
+        total_fixes = sum(fixed_by_file.values())
+        lines.append(
+            f"Auto-fix aplicado: {total_fixes} cambios en "
+            f"{len(fixed_by_file)} archivos."
+        )
+        lines.append("")
+
+    shown = 0
+    for source, items in sorted(violations_by_file.items()):
+        if limit and shown >= limit:
+            remaining = total_violations - shown
+            lines.append(f"... y {remaining} mas. Sube 'limit' para verlas todas.")
+            break
+        lines.append(f"{source}:")
+        for item in items:
+            if limit and shown >= limit:
+                break
+            lines.append(f"  - {item}")
+            shown += 1
+        lines.append("")
+
+    return Result.ok("\n".join(lines))
+
+
 def find_broken_wikilinks(limit: int = 100) -> Result[str]:
     """Scan the vault for wikilinks whose target note doesn't exist (Issue #6).
 

--- a/obsidian_mcp/tools/analysis_logic.py
+++ b/obsidian_mcp/tools/analysis_logic.py
@@ -21,7 +21,7 @@ logger = get_logger(__name__)
 HEX_COLOR_PATTERN = re.compile(r"^([0-9a-fA-F]{3}){1,2}$")
 
 
-def get_vault_stats() -> Result[str]:
+def get_vault_stats() -> Result[str]:  # pylint: disable=too-many-locals
     """Generate complete vault statistics.
 
     Returns:
@@ -147,7 +147,7 @@ def get_canonical_tags() -> Result[str]:
     )
 
 
-def analyze_tags() -> Result[str]:
+def analyze_tags() -> Result[str]:  # pylint: disable=too-many-locals,too-many-branches
     """Analyze tag usage in the vault and compare with official registry.
 
     Returns:
@@ -249,7 +249,9 @@ def analyze_tags() -> Result[str]:
     return Result.ok(resultado)
 
 
-def sync_tag_registry(actualizar: bool = False) -> Result[str]:
+def sync_tag_registry(  # pylint: disable=too-many-locals,too-many-branches
+    actualizar: bool = False,
+) -> Result[str]:
     """Synchronize tag usage with official registry.
 
     Args:
@@ -454,6 +456,64 @@ def analyze_links() -> Result[str]:
             resultado += f"   ... y {len(enlaces_rotos) - 10} enlaces rotos más\n"
 
     return Result.ok(resultado)
+
+
+def find_broken_wikilinks(limit: int = 100) -> Result[str]:
+    """Scan the vault for wikilinks whose target note doesn't exist (Issue #6).
+
+    For each broken link surfaces source file + line + the closest existing
+    stems as fuzzy suggestions, so the agent can fix typos and renames in
+    one pass instead of grepping the vault manually.
+
+    Args:
+        limit: Maximum number of broken links to include in the report.
+
+    Returns:
+        Result with a structured per-source listing and suggestions.
+    """
+    from ..utils.wikilinks import scan_broken_wikilinks  # local to avoid cycles
+
+    vault_path = get_vault_path()
+    if not vault_path:
+        return Result.fail("La ruta del vault no está configurada.")
+
+    if limit < 0:
+        return Result.fail("limit debe ser >= 0.")
+
+    broken = scan_broken_wikilinks(vault_path)
+    if not broken:
+        return Result.ok("OK No se encontraron wikilinks rotos en el vault.")
+
+    grouped: dict[str, list[str]] = {}
+    for item in broken[: limit if limit else len(broken)]:
+        rel = str(item.occurrence.source.relative_to(vault_path))
+        suggestions = (
+            f" -> sugerencias: {', '.join(item.suggestions)}"
+            if item.suggestions
+            else " -> sin sugerencias"
+        )
+        line = (
+            f"  L{item.occurrence.line_no}: [[{item.occurrence.raw}]]"
+            f" (target='{item.occurrence.target}'){suggestions}"
+        )
+        grouped.setdefault(rel, []).append(line)
+
+    header = (
+        f"Wikilinks rotos: {len(broken)} (mostrando "
+        f"{min(limit, len(broken)) if limit else len(broken)}).\n\n"
+    )
+    body_lines: list[str] = []
+    for source, items in sorted(grouped.items()):
+        body_lines.append(f"{source}:")
+        body_lines.extend(items)
+        body_lines.append("")
+
+    if limit and len(broken) > limit:
+        body_lines.append(
+            f"... y {len(broken) - limit} mas. Sube 'limit' para verlos todos."
+        )
+
+    return Result.ok(header + "\n".join(body_lines))
 
 
 def get_recent_activity(dias: int = 7) -> Result[str]:

--- a/obsidian_mcp/tools/context.py
+++ b/obsidian_mcp/tools/context.py
@@ -19,7 +19,7 @@ from .registry import register_tool
 def register_context_tools(mcp: FastMCP) -> None:
     """Register vault context tools."""
 
-    @register_tool(mcp, "read_vault_context")
+    @register_tool(mcp, "vault.context")
     def read_vault_context() -> str:
         """Read the vault structure, templates, and common metadata."""
         try:
@@ -27,7 +27,7 @@ def register_context_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error reading vault context: {e}"
 
-    @register_tool(mcp, "health_check")
+    @register_tool(mcp, "vault.health")
     def health_check() -> str:
         """Validate the active vault and MCP profile configuration."""
         try:
@@ -35,7 +35,7 @@ def register_context_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error running health check: {e}"
 
-    @register_tool(mcp, "diagnose_vault_setup")
+    @register_tool(mcp, "vault.diagnose")
     def diagnose_vault_setup() -> str:
         """Diagnose vault setup issues and return actionable recommendations."""
         try:
@@ -43,7 +43,7 @@ def register_context_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error diagnosing vault setup: {e}"
 
-    @register_tool(mcp, "list_client_roots")
+    @register_tool(mcp, "client.roots")
     async def list_client_roots(ctx: Context) -> str:
         """List filesystem roots advertised by the connected MCP client."""
         try:
@@ -71,7 +71,7 @@ def register_context_tools(mcp: FastMCP) -> None:
             }
             return json.dumps(payload, ensure_ascii=False, indent=2)
 
-    @register_tool(mcp, "route_task")
+    @register_tool(mcp, "route.task")
     def route_task(request: str) -> str:
         """Recommend prompts, skills, resources, and tools for a task."""
         try:

--- a/obsidian_mcp/tools/context_logic.py
+++ b/obsidian_mcp/tools/context_logic.py
@@ -292,7 +292,7 @@ def diagnose_vault_setup_report() -> Result[str]:
                 )
             elif "invalid_skills_found" in line:
                 recommendations.append(
-                    "Run `sync_skills(update=False)` to inspect invalid skills."
+                    "Run `skills.sync(update=False)` to inspect invalid skills."
                 )
             elif "standard:" in line:
                 recommendations.append(
@@ -432,7 +432,7 @@ def _infer_route(
         if "obsidianrag" in integrations or "obsidianrag" in tool_sets:
             tools.extend(["rag_health", "ask_vault", "ObsidianRAG"])
             notes = (
-                "Use ObsidianRAG for natural-language vault QA. Run `rag_health` first; "
+                "Use ObsidianRAG for natural-language vault QA. Run `rag.health` first; "
                 "if the backend is offline, read `obsidian://integrations/obsidianrag/setup`."
             )
         return _route(

--- a/obsidian_mcp/tools/creation.py
+++ b/obsidian_mcp/tools/creation.py
@@ -62,7 +62,7 @@ def _parse_tags(tags: str) -> list[str]:
 def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-statements
     """Register note creation and editing tools."""
 
-    @register_tool(mcp, "list_templates")
+    @register_tool(mcp, "templates.list")
     def list_templates() -> str:
         """List available note templates."""
         try:
@@ -70,7 +70,7 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error listing templates: {e}"
 
-    @register_tool(mcp, "suggest_note_location")
+    @register_tool(mcp, "notes.suggest_location")
     def suggest_note_location(title: str, content: str, tags: str = "") -> str:
         """Suggest candidate vault folders for a new note."""
         try:
@@ -78,7 +78,7 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error suggesting note location: {e}"
 
-    @register_tool(mcp, "create_note")
+    @register_tool(mcp, "notes.create")
     def create_note(
         title: str,
         content: str,
@@ -101,7 +101,7 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
                 description,
             ).to_display(success_prefix="OK")
             return enrich_response(
-                tool_name="create_note",
+                tool_name="notes.create",
                 result=result,
                 title=title,
                 content=content,
@@ -110,7 +110,7 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error creating note: {e}"
 
-    @register_tool(mcp, "append_to_note")
+    @register_tool(mcp, "notes.append")
     def append_to_note(
         note_path: str,
         content: str,
@@ -137,14 +137,14 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
                 return "Error: position must be 'end', 'start', or 'section'."
 
             return enrich_response(
-                tool_name="append_to_note",
+                tool_name="notes.append",
                 result=result,
                 content=content,
             )
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error appending to note: {e}"
 
-    @register_tool(mcp, "delete_note")
+    @register_tool(mcp, "notes.delete")
     async def delete_note(note_path: str, ctx: Context) -> str:
         """Delete a note after explicit client confirmation."""
         try:
@@ -164,7 +164,7 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error deleting note: {e}"
 
-    @register_tool(mcp, "patch_note")
+    @register_tool(mcp, "notes.patch")
     def patch_note(note_path: str, operations: list[EditOperation]) -> str:
         """Patch a note with atomic exact-match replacements.
 
@@ -193,14 +193,14 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
                 operation["new"] for operation in normalized_operations
             )
             return enrich_response(
-                tool_name="patch_note",
+                tool_name="notes.patch",
                 result=result,
                 content=combined_new,
             )
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error patching note: {e}"
 
-    @register_tool(mcp, "replace_note")
+    @register_tool(mcp, "notes.replace")
     async def replace_note(note_path: str, content: str, ctx: Context) -> str:
         """Replace the full content of a note after explicit confirmation."""
         try:
@@ -220,14 +220,14 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
             if "REGLAS_GLOBALES" in note_path:
                 invalidate_rules_cache()
             return enrich_response(
-                tool_name="replace_note",
+                tool_name="notes.replace",
                 result=edit_result,
                 content=content,
             )
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error replacing note: {e}"
 
-    @register_tool(mcp, "preview_replace_in_notes")
+    @register_tool(mcp, "notes.preview_replace")
     def preview_replace_in_notes(
         search: str,
         replacement: str,
@@ -246,7 +246,7 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error previewing replacement: {e}"
 
-    @register_tool(mcp, "apply_replace_in_notes")
+    @register_tool(mcp, "notes.apply_replace")
     async def apply_replace_in_notes(
         search: str,
         replacement: str,
@@ -277,13 +277,13 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error applying replacement: {e}"
 
-    @register_tool(mcp, "quick_capture")
+    @register_tool(mcp, "inbox.capture")
     def quick_capture(text: str, tags: str = "") -> str:
         """Capture an inbox note in the personal vault profile."""
         try:
             result = quick_capture_logic(text, tags).to_display()
             return enrich_response(
-                tool_name="quick_capture",
+                tool_name="inbox.capture",
                 result=result,
                 title=text[:80],
                 content=text,
@@ -291,7 +291,7 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error creating quick capture: {e}"
 
-    @register_tool(mcp, "get_frontmatter")
+    @register_tool(mcp, "notes.get_frontmatter")
     def get_frontmatter(note_path: str) -> str:
         """Return only a note frontmatter block as JSON."""
         try:
@@ -299,7 +299,7 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error reading frontmatter: {e}"
 
-    @register_tool(mcp, "update_frontmatter")
+    @register_tool(mcp, "notes.update_frontmatter")
     def update_frontmatter(
         note_path: str,
         frontmatter_updates: str,
@@ -319,14 +319,14 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
                 frontmatter = {}
 
             return enrich_response(
-                tool_name="update_frontmatter",
+                tool_name="notes.update_frontmatter",
                 result=result,
                 frontmatter=frontmatter,
             )
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error updating frontmatter: {e}"
 
-    @register_tool(mcp, "update_note_tags")
+    @register_tool(mcp, "notes.update_tags")
     def update_note_tags(note_path: str, operation: str, tags: str = "") -> str:
         """Add, remove, or set YAML tags on a note."""
         try:

--- a/obsidian_mcp/tools/creation.py
+++ b/obsidian_mcp/tools/creation.py
@@ -35,6 +35,18 @@ from .creation_logic import (
 from .registry import register_tool
 
 
+def _cancellation_reason(action: str) -> str:
+    """Map elicit() action to a specific Spanish reason (Issue #1).
+
+    `action` values per MCP spec: 'accept', 'decline', 'cancel'.
+    """
+    if action == "decline":
+        return ERRORS.OPERATION_DECLINED
+    if action == "cancel":
+        return ERRORS.OPERATION_DISMISSED
+    return ERRORS.OPERATION_DECLINED
+
+
 def _extract_fm(content: str) -> dict:
     """Extract frontmatter dict from content for middleware validation."""
     from .creation_logic import _extract_frontmatter_from_content
@@ -141,7 +153,7 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
                 response_type=None,
             )
             if result.action != "accept":
-                return ERRORS.OPERATION_CANCELLED
+                return _cancellation_reason(result.action)
         except Exception:  # pylint: disable=broad-exception-caught
             return ERRORS.OPERATION_CANCELLED_NO_CONFIRM
 
@@ -197,7 +209,7 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
                 response_type=None,
             )
             if confirmation.action != "accept":
-                return ERRORS.OPERATION_CANCELLED
+                return _cancellation_reason(confirmation.action)
         except Exception:  # pylint: disable=broad-exception-caught
             return ERRORS.OPERATION_CANCELLED_NO_CONFIRM
 
@@ -250,7 +262,7 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
                 response_type=None,
             )
             if result.action != "accept":
-                return ERRORS.OPERATION_CANCELLED
+                return _cancellation_reason(result.action)
         except Exception:  # pylint: disable=broad-exception-caught
             return ERRORS.OPERATION_CANCELLED_NO_CONFIRM
 

--- a/obsidian_mcp/tools/creation.py
+++ b/obsidian_mcp/tools/creation.py
@@ -4,6 +4,7 @@ import json
 
 from fastmcp import Context, FastMCP
 
+from ..messages import ERRORS
 from ..middleware import enrich_response, invalidate_rules_cache
 from ..models.tool_inputs import EditOperation
 from .creation_logic import (
@@ -140,12 +141,9 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
                 response_type=None,
             )
             if result.action != "accept":
-                return "Operation cancelled."
+                return ERRORS.OPERATION_CANCELLED
         except Exception:  # pylint: disable=broad-exception-caught
-            return (
-                "Interactive confirmation is not supported by this client. "
-                "The delete operation was cancelled for safety."
-            )
+            return ERRORS.OPERATION_CANCELLED_NO_CONFIRM
 
         try:
             return delete_note_logic(note_path, confirmar=True).to_display(
@@ -199,12 +197,9 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
                 response_type=None,
             )
             if confirmation.action != "accept":
-                return "Operation cancelled."
+                return ERRORS.OPERATION_CANCELLED
         except Exception:  # pylint: disable=broad-exception-caught
-            return (
-                "Interactive confirmation is not supported by this client. "
-                "The replace operation was cancelled for safety."
-            )
+            return ERRORS.OPERATION_CANCELLED_NO_CONFIRM
 
         try:
             edit_result = edit_note(
@@ -255,13 +250,9 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
                 response_type=None,
             )
             if result.action != "accept":
-                return "Operation cancelled."
+                return ERRORS.OPERATION_CANCELLED
         except Exception:  # pylint: disable=broad-exception-caught
-            return (
-                "Interactive confirmation is not supported by this client. "
-                "Run preview_replace_in_notes first and retry with a client "
-                "that supports confirmation."
-            )
+            return ERRORS.OPERATION_CANCELLED_NO_CONFIRM
 
         try:
             return search_and_replace_global(

--- a/obsidian_mcp/tools/creation_logic.py
+++ b/obsidian_mcp/tools/creation_logic.py
@@ -10,6 +10,7 @@ All functions return Result[str] for consistent error handling.
 
 # pylint: disable=too-many-lines
 
+import difflib
 import json
 import re
 from datetime import date, datetime
@@ -146,6 +147,48 @@ def _process_date_placeholders(content: str, date_obj: datetime | None = None) -
     return content
 
 
+def _suggest_close_matches(
+    needle: str, haystack: str, max_suggestions: int = 3, cutoff: float = 0.6
+) -> list[str]:
+    """Find lines or line-windows in ``haystack`` that look like ``needle``.
+
+    Used by ``edit_note`` when an exact-match ``old`` text isn't found, so
+    the agent gets actionable suggestions instead of guessing emoji
+    codepoints or whitespace variants (Issue #8).
+
+    Returns up to ``max_suggestions`` candidate strings, ordered by
+    similarity. Empty list if nothing crosses the ``cutoff`` ratio.
+    """
+    if not needle.strip() or not haystack:
+        return []
+
+    needle_lines = needle.splitlines() or [needle]
+    haystack_lines = haystack.splitlines()
+    window = len(needle_lines)
+
+    if window == 1:
+        candidates = haystack_lines
+    else:
+        candidates = [
+            "\n".join(haystack_lines[i : i + window])
+            for i in range(len(haystack_lines) - window + 1)
+        ]
+
+    matcher = difflib.SequenceMatcher(autojunk=False)
+    matcher.set_seq2(needle)
+    scored: list[tuple[float, str]] = []
+    for cand in candidates:
+        if not cand.strip() or cand == needle:
+            continue
+        matcher.set_seq1(cand)
+        ratio = matcher.ratio()
+        if ratio >= cutoff:
+            scored.append((ratio, cand))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [cand for _, cand in scored[:max_suggestions]]
+
+
 def _extract_frontmatter_from_content(contenido: str) -> tuple[dict[str, Any], str]:
     """Extract YAML frontmatter from content if it exists."""
     frontmatter_pattern = re.compile(r"^---\s*\n(.*?)\n---\s*\n?", re.DOTALL)
@@ -171,14 +214,21 @@ def _build_frontmatter(
     agente_creador: str = "",
     extra_metadata: dict[str, Any] | None = None,
 ) -> str:
-    """Build YAML frontmatter block combining metadata."""
+    """Build YAML frontmatter block combining metadata.
+
+    Issue #2: when ``extra_metadata`` carries an embedded frontmatter block
+    extracted from ``content``, its fields take precedence over the
+    parameter-derived defaults. Filename identity is still the caller's
+    ``titulo`` argument; the frontmatter ``title`` reflects what the
+    author wrote.
+    """
     metadata: dict[str, Any] = {}
 
     if extra_metadata:
         metadata.update(extra_metadata)
 
-    metadata["title"] = titulo
-    metadata["created"] = ahora
+    metadata.setdefault("title", titulo)
+    metadata.setdefault("created", ahora)
 
     existing_tags = metadata.get("tags", [])
     if isinstance(existing_tags, str):
@@ -442,9 +492,14 @@ def edit_note(  # pylint: disable=too-many-locals,too-many-return-statements,too
         count = contenido_actual.count(old_text)
         if count == 0:
             preview = old_text[:80] + ("..." if len(old_text) > 80 else "")
-            return Result.fail(
+            suggestions = _suggest_close_matches(old_text, contenido_actual)
+            base_msg = (
                 f"No se encontro el texto: '{preview}' en la nota {ruta_relativa}"
             )
+            if suggestions:
+                hint_lines = "\n".join(f"  - {s!r}" for s in suggestions)
+                base_msg += "\nQuiza quisiste decir:\n" + hint_lines
+            return Result.fail(base_msg)
         if count > 1:
             preview = old_text[:80] + ("..." if len(old_text) > 80 else "")
             return Result.fail(

--- a/obsidian_mcp/tools/graph.py
+++ b/obsidian_mcp/tools/graph.py
@@ -20,7 +20,7 @@ from .registry import register_tool
 def register_graph_tools(mcp: FastMCP) -> None:
     """Register graph and relationship tools."""
 
-    @register_tool(mcp, "get_backlinks")
+    @register_tool(mcp, "links.backlinks")
     def get_backlinks(note_path: str) -> str:
         """List notes that link to the given note."""
         try:
@@ -28,7 +28,7 @@ def register_graph_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error reading backlinks: {e}"
 
-    @register_tool(mcp, "get_notes_by_tag")
+    @register_tool(mcp, "tags.notes_with")
     def get_notes_by_tag(tag: str) -> str:
         """List notes that contain a specific tag."""
         try:
@@ -36,7 +36,7 @@ def register_graph_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error finding notes by tag: {e}"
 
-    @register_tool(mcp, "get_local_graph")
+    @register_tool(mcp, "links.local_graph")
     def get_local_graph(note_path: str, depth: int = 1) -> str:
         """Read incoming and outgoing links around a note."""
         try:
@@ -44,7 +44,7 @@ def register_graph_tools(mcp: FastMCP) -> None:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error reading local graph: {e}"
 
-    @register_tool(mcp, "find_orphan_notes")
+    @register_tool(mcp, "links.find_orphans")
     def find_orphan_notes() -> str:
         """Find notes without incoming or outgoing wikilinks."""
         try:

--- a/obsidian_mcp/tools/navigation.py
+++ b/obsidian_mcp/tools/navigation.py
@@ -57,7 +57,7 @@ def _format_search_results(results: list[dict[str, str]], titles_only: bool) -> 
 def register_navigation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-statements
     """Register navigation tools."""
 
-    @register_tool(mcp, "list_notes")
+    @register_tool(mcp, "notes.list")
     def list_notes(
         folder: str = "",
         include_subfolders: bool = True,
@@ -82,7 +82,7 @@ def register_navigation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error listing notes: {e}"
 
-    @register_tool(mcp, "read_note")
+    @register_tool(mcp, "notes.read")
     def read_note(note_path: str) -> str:
         """
         Read the full content of a note.
@@ -95,7 +95,7 @@ def register_navigation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error reading note: {e}"
 
-    @register_tool(mcp, "search_notes")
+    @register_tool(mcp, "notes.search")
     def search_notes(  # pylint: disable=too-many-locals,too-many-branches,too-many-statements,too-many-nested-blocks
         query: str,
         folder: str = "",
@@ -275,7 +275,7 @@ def register_navigation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many
             logger.error("Unexpected search error: %s", e)
             return f"Search error: {e}"
 
-    @register_tool(mcp, "search_notes_by_date")
+    @register_tool(mcp, "notes.search_by_date")
     def search_notes_by_date(start_date: str, end_date: str = "") -> str:
         """
         Search notes modified in a date range.
@@ -289,7 +289,7 @@ def register_navigation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Date search error: {e}"
 
-    @register_tool(mcp, "move_note")
+    @register_tool(mcp, "notes.move")
     def move_note(
         source: str,
         destination: str,
@@ -316,7 +316,7 @@ def register_navigation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Move note error: {e}"
 
-    @register_tool(mcp, "rename_note")
+    @register_tool(mcp, "notes.rename")
     def rename_note(source: str, new_name: str, update_links: bool = True) -> str:
         """
         Rename a note in place, optionally rewriting every wikilink to it.
@@ -345,7 +345,7 @@ def register_navigation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Rename note error: {e}"
 
-    @register_tool(mcp, "random_concept")
+    @register_tool(mcp, "random.concept")
     def random_concept(folder: str = "") -> str:
         """
         Return a random concept from the vault as a surprise flashcard.
@@ -358,7 +358,7 @@ def register_navigation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Random concept error: {e}"
 
-    @register_tool(mcp, "read_notes")
+    @register_tool(mcp, "notes.read_many")
     async def read_notes(paths: list[str], ctx: Context) -> str:
         """
         Read the content and frontmatter of multiple notes.
@@ -377,7 +377,7 @@ def register_navigation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Read notes error: {e}"
 
-    @register_tool(mcp, "get_note_info")
+    @register_tool(mcp, "notes.info")
     def get_note_info(paths: list[str]) -> str:
         """
         Return metadata for multiple notes without loading all content.

--- a/obsidian_mcp/tools/navigation.py
+++ b/obsidian_mcp/tools/navigation.py
@@ -58,16 +58,27 @@ def register_navigation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many
     """Register navigation tools."""
 
     @register_tool(mcp, "list_notes")
-    def list_notes(folder: str = "", include_subfolders: bool = True) -> str:
+    def list_notes(
+        folder: str = "",
+        include_subfolders: bool = True,
+        limit: int = 500,
+        offset: int = 0,
+        pattern: str = "",
+    ) -> str:
         """
         List Markdown notes in the vault or in a specific folder.
 
         Args:
             folder: Folder to explore. Empty means the vault root.
             include_subfolders: Whether to include nested folders.
+            limit: Max notes per page (0 = no limit). Defaults to 500.
+            offset: Start index (after path sort).
+            pattern: Optional glob (e.g. "2026-*.md") layered on top of *.md.
         """
         try:
-            return list_notes_logic(folder, include_subfolders).to_display()
+            return list_notes_logic(
+                folder, include_subfolders, limit=limit, offset=offset, pattern=pattern
+            ).to_display()
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error listing notes: {e}"
 

--- a/obsidian_mcp/tools/navigation.py
+++ b/obsidian_mcp/tools/navigation.py
@@ -290,7 +290,12 @@ def register_navigation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many
             return f"Date search error: {e}"
 
     @register_tool(mcp, "move_note")
-    def move_note(source: str, destination: str, create_folders: bool = True) -> str:
+    def move_note(
+        source: str,
+        destination: str,
+        create_folders: bool = True,
+        update_links: bool = False,
+    ) -> str:
         """
         Move or rename a note inside the vault.
 
@@ -298,13 +303,47 @@ def register_navigation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many
             source: Current relative note path.
             destination: New relative note path.
             create_folders: Whether to create destination folders.
+            update_links: When True, rewrite every wikilink across the
+                vault that targets the old stem so it targets the new
+                one (aliases and section anchors preserved). When False,
+                the response still reports how many wikilinks now point
+                at a stale stem.
         """
         try:
-            return move_note_logic(source, destination, create_folders).to_display(
-                success_prefix="OK"
-            )
+            return move_note_logic(
+                source, destination, create_folders, update_links=update_links
+            ).to_display(success_prefix="OK")
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Move note error: {e}"
+
+    @register_tool(mcp, "rename_note")
+    def rename_note(source: str, new_name: str, update_links: bool = True) -> str:
+        """
+        Rename a note in place, optionally rewriting every wikilink to it.
+
+        Args:
+            source: Current relative note path (e.g. ``notes/Old Name.md``).
+            new_name: New filename stem (no ``.md``). The note stays in
+                the same folder. Pass a full path to also move it.
+            update_links: When True (default), rewrite vault-wide
+                wikilink references from the old stem to the new one.
+        """
+        try:
+            src = Path(source)
+            if new_name.endswith(".md"):
+                new_name = new_name[:-3]
+            if "/" in new_name:
+                destination = new_name + ".md"
+            else:
+                destination = str(src.with_name(f"{new_name}.md"))
+            return move_note_logic(
+                source,
+                destination,
+                crear_carpetas=False,
+                update_links=update_links,
+            ).to_display(success_prefix="OK")
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            return f"Rename note error: {e}"
 
     @register_tool(mcp, "random_concept")
     def random_concept(folder: str = "") -> str:

--- a/obsidian_mcp/tools/navigation_logic.py
+++ b/obsidian_mcp/tools/navigation_logic.py
@@ -323,17 +323,29 @@ def _validate_move_paths(
     return True, ""
 
 
-def move_note(origen: str, destino: str, crear_carpetas: bool = True) -> Result[str]:
+def move_note(  # pylint: disable=too-many-locals,too-many-return-statements
+    origen: str,
+    destino: str,
+    crear_carpetas: bool = True,
+    update_links: bool = False,
+) -> Result[str]:
     """Move or rename a note within the vault.
 
     Args:
-        origen: Current relative path of the note
-        destino: New relative path for the note
-        crear_carpetas: Whether to create destination folders if needed
+        origen: Current relative path of the note.
+        destino: New relative path for the note.
+        crear_carpetas: Whether to create destination folders if needed.
+        update_links: When True (Issue #7/#11), rewrite every wikilink
+            across the vault that points to the old stem so they target
+            the new stem instead. Aliases/sections are preserved.
 
     Returns:
-        Result with success or error message
+        Result with success or error message. On success, the message
+        reports how many wikilinks were touched (or 0 if update_links
+        was False) so the agent doesn't have to guess.
     """
+    from ..utils.wikilinks import rewrite_wikilinks_in_vault
+
     vault_path = get_vault_path()
     if not vault_path:
         return Result.fail("Vault path is not configured.")
@@ -361,9 +373,30 @@ def move_note(origen: str, destino: str, crear_carpetas: bool = True) -> Result[
             f"Destination folder does not exist: {path_destino.parent.name}"
         )
 
+    old_stem = path_origen.stem
+    new_stem = path_destino.stem
+
     path_origen.rename(path_destino)
 
-    return Result.ok(f"File moved/renamed:\nFrom: {origen}\nTo:   {destino}")
+    msg = f"File moved/renamed:\nFrom: {origen}\nTo:   {destino}"
+
+    if update_links and old_stem != new_stem:
+        total, touched = rewrite_wikilinks_in_vault(
+            vault_path, old_target=old_stem, new_target=new_stem
+        )
+        msg += f"\nLinks updated: {total} references across {len(touched)} files."
+    elif not update_links:
+        # Issue #11: surface impact even when we didn't rewrite.
+        total, touched = rewrite_wikilinks_in_vault(
+            vault_path, old_target=old_stem, new_target=new_stem, dry_run=True
+        )
+        if old_stem != new_stem and total > 0:
+            msg += (
+                f"\nWarning: {total} wikilinks across {len(touched)} files now point "
+                f"to the old stem '{old_stem}'. Re-run with update_links=True to fix."
+            )
+
+    return Result.ok(msg)
 
 
 def _is_content_paragraph(line: str) -> bool:

--- a/obsidian_mcp/tools/navigation_logic.py
+++ b/obsidian_mcp/tools/navigation_logic.py
@@ -215,7 +215,7 @@ def read_note(nombre_archivo: str) -> Result[str]:
     size_bytes = nota_path.stat().st_size
     if size_bytes > MAX_NOTE_READ_BYTES:
         return Result.fail(
-            "Note is too large to return safely. Use `get_note_info` first and "
+            "Note is too large to return safely. Use `notes.info` first and "
             "read a smaller section or split the note."
         )
 
@@ -492,7 +492,7 @@ def get_random_concept(carpeta: str = "") -> Result[str]:
     if tags:
         resultado += f"Tags: {tags}\n"
     resultado += f"\n---\n\n{fragmento}\n"
-    resultado += f'\n---\n*Want to go deeper? Use `read_note("{ruta_relativa}")`*'
+    resultado += f'\n---\n*Want to go deeper? Use `notes.read("{ruta_relativa}")`*'
 
     return Result.ok(resultado)
 

--- a/obsidian_mcp/tools/navigation_logic.py
+++ b/obsidian_mcp/tools/navigation_logic.py
@@ -78,19 +78,42 @@ def format_search_results(resultados: list, solo_titulos: bool) -> str:
     return resultado_str
 
 
-def list_notes(carpeta: str = "", incluir_subcarpetas: bool = True) -> Result[str]:
-    """List all notes in the vault or a specific folder.
+DEFAULT_LIST_NOTES_LIMIT = 500
+
+
+def list_notes(  # pylint: disable=too-many-locals,too-many-branches
+    carpeta: str = "",
+    incluir_subcarpetas: bool = True,
+    limit: int = DEFAULT_LIST_NOTES_LIMIT,
+    offset: int = 0,
+    pattern: str = "",
+) -> Result[str]:
+    """List notes in the vault or a specific folder, with pagination.
+
+    Issue #5: large vaults overran the response budget (125K+ chars on
+    single call). ``limit``/``offset`` cap the output and the footer
+    points at the next page.
 
     Args:
-        carpeta: Specific folder to explore (empty = vault root)
-        incluir_subcarpetas: Whether to include subfolders in search
+        carpeta: Specific folder to explore (empty = vault root).
+        incluir_subcarpetas: Whether to recurse into subfolders.
+        limit: Max notes to include in the response. Use 0 for "no limit".
+        offset: Start index (after filename sort).
+        pattern: Optional glob (e.g. ``"2026-*.md"``) layered over the
+            base ``*.md`` discovery.
 
     Returns:
-        Result with formatted string of notes organized by folder
+        Result with a formatted listing plus pagination footer when
+        more notes exist beyond ``offset + limit``.
     """
     vault_path = get_vault_path()
     if not vault_path:
         return Result.fail("Vault path is not configured.")
+
+    if limit < 0:
+        return Result.fail("limit debe ser >= 0 (0 = sin limite).")
+    if offset < 0:
+        return Result.fail("offset debe ser >= 0.")
 
     if carpeta:
         target_path = vault_path / carpeta
@@ -99,34 +122,58 @@ def list_notes(carpeta: str = "", incluir_subcarpetas: bool = True) -> Result[st
     else:
         target_path = vault_path
 
-    pattern = "**/*.md" if incluir_subcarpetas else "*.md"
-    notas = list(target_path.glob(pattern))
+    base_pattern = "**/*.md" if incluir_subcarpetas else "*.md"
+    if pattern:
+        glob_pattern = (
+            f"**/{pattern}"
+            if incluir_subcarpetas and not pattern.startswith("**/")
+            else pattern
+        )
+    else:
+        glob_pattern = base_pattern
 
-    if not notas:
-        return Result.ok(f"No notes found in '{carpeta or 'root'}'")
+    notas_raw = list(target_path.glob(glob_pattern))
 
-    notas_por_carpeta: dict[str, list[dict]] = {}
+    visibles: list[Path] = []
     notas_filtradas = 0
-    for nota in notas:
+    for nota in notas_raw:
         is_forbidden, _ = is_path_forbidden(nota, vault_path)
         if is_forbidden:
             notas_filtradas += 1
             continue
+        visibles.append(nota)
 
+    total_visibles = len(visibles)
+
+    if total_visibles == 0:
+        return Result.ok(f"No notes found in '{carpeta or 'root'}'")
+
+    visibles.sort(key=lambda p: str(p.relative_to(vault_path)))
+
+    end = total_visibles if limit == 0 else min(offset + limit, total_visibles)
+    page = visibles[offset:end]
+
+    if not page:
+        return Result.ok(
+            f"No notes in this page (offset={offset}, limit={limit}). "
+            f"Total visibles: {total_visibles}."
+        )
+
+    notas_por_carpeta: dict[str, list[dict]] = {}
+    for nota in page:
         ruta_relativa = nota.relative_to(vault_path)
         carpeta_padre = (
             str(ruta_relativa.parent) if ruta_relativa.parent != Path(".") else "Root"
         )
-
         if carpeta_padre not in notas_por_carpeta:
             notas_por_carpeta[carpeta_padre] = []
+        notas_por_carpeta[carpeta_padre].append(get_note_metadata(nota))
 
-        metadata = get_note_metadata(nota)
-        notas_por_carpeta[carpeta_padre].append(metadata)
-
-    total_visibles = len(notas) - notas_filtradas
-
-    resultado = f"Notes found in the vault ({total_visibles} total):\n\n"
+    header = (
+        f"Notes found in the vault ({total_visibles} total, "
+        f"showing {offset + 1}-{end}):\n\n"
+    )
+    resultado = header
 
     for carpeta_nombre, lista_notas in sorted(notas_por_carpeta.items()):
         resultado += f"{carpeta_nombre} ({len(lista_notas)} notes):\n"
@@ -136,6 +183,13 @@ def list_notes(carpeta: str = "", incluir_subcarpetas: bool = True) -> Result[st
                 f"({nota_meta['size_kb']:.1f}KB, {nota_meta['modified']})\n"
             )
         resultado += "\n"
+
+    if end < total_visibles:
+        next_offset = end
+        resultado += (
+            f"--- Truncated: {total_visibles - end} more notes available. "
+            f"Call list_notes(offset={next_offset}, limit={limit}) for the next page."
+        )
 
     return Result.ok(resultado)
 

--- a/obsidian_mcp/tools/obsidianrag.py
+++ b/obsidian_mcp/tools/obsidianrag.py
@@ -28,7 +28,7 @@ def register_obsidianrag_tools(mcp: FastMCP) -> None:
     if not _is_obsidianrag_enabled():
         return
 
-    @register_tool(mcp, "rag_setup_status")
+    @register_tool(mcp, "rag.setup_status")
     def rag_setup_status() -> str:
         """
         Inspect local ObsidianRAG setup status.
@@ -38,14 +38,14 @@ def register_obsidianrag_tools(mcp: FastMCP) -> None:
         """
         return get_rag_setup_status().to_display()
 
-    @register_tool(mcp, "rag_health")
+    @register_tool(mcp, "rag.health")
     def rag_health() -> str:
         """
         Check whether the ObsidianRAG backend is reachable and ready.
         """
         return check_rag_health().to_display()
 
-    @register_tool(mcp, "ask_vault")
+    @register_tool(mcp, "rag.ask")
     def ask_vault(question: str, session_id: str | None = None) -> str:
         """
         Ask a natural-language question against the Obsidian vault via ObsidianRAG.
@@ -56,7 +56,7 @@ def register_obsidianrag_tools(mcp: FastMCP) -> None:
         """
         return ask_rag(question, session_id).to_display()
 
-    @register_tool(mcp, "rebuild_rag_index")
+    @register_tool(mcp, "rag.rebuild_index")
     def rebuild_rag_index() -> str:
         """
         Rebuild the ObsidianRAG index after large vault changes.
@@ -108,8 +108,10 @@ def get_rag_setup_status() -> Result[str]:
     )
     output += "\n\n## Next Actions\n"
     if health.success:
-        output += "- ObsidianRAG is reachable. Use `ask_vault` for semantic vault questions.\n"
-        output += "- Run `rebuild_rag_index` after big vault reorganizations.\n"
+        output += (
+            "- ObsidianRAG is reachable. Use `rag.ask` for semantic vault questions.\n"
+        )
+        output += "- Run `rag.rebuild_index` after big vault reorganizations.\n"
     else:
         output += "- Read `obsidian://integrations/obsidianrag/setup`.\n"
         output += "- Start Ollama or another supported LLM provider.\n"
@@ -153,7 +155,7 @@ def ask_rag(question: str, session_id: str | None = None) -> Result[str]:
     )
     if not result.success:
         return Result.fail(
-            "ObsidianRAG query failed. Check `rag_health` and "
+            "ObsidianRAG query failed. Check `rag.health` and "
             "`obsidian://integrations/obsidianrag/setup`."
         )
 
@@ -183,7 +185,7 @@ def rebuild_rag_database() -> Result[str]:
     )
     if not result.success:
         return Result.fail(
-            "Could not rebuild ObsidianRAG index. Check `rag_health` first."
+            "Could not rebuild ObsidianRAG index. Check `rag.health` first."
         )
     return Result.ok(json.dumps(result.data, ensure_ascii=False, indent=2))
 
@@ -242,13 +244,13 @@ silently.
 
 ## Agent Checklist
 
-1. Run `rag_setup_status`.
-2. Run `list_client_roots` to confirm the client exposes the expected workspace roots.
+1. Run `rag.setup_status`.
+2. Run `client.roots` to confirm the client exposes the expected workspace roots.
 3. If Ollama is missing, help the user install/start Ollama and pull a local model.
 4. Install backend dependencies from the ObsidianRAG backend folder.
 5. Start the backend.
-6. Run `rag_health`.
-7. Run `rebuild_rag_index` for the first index. Large vaults can take several minutes.
+6. Run `rag.health`.
+7. Run `rag.rebuild_index` for the first index. Large vaults can take several minutes.
 8. Ask the user to restart or reconnect the MCP client if new tools were just enabled.
 
 ## Environment
@@ -289,9 +291,9 @@ Call tool: ask_vault(question="...")
 
 ## Troubleshooting
 
-- If `rag_health` fails, confirm the server is listening at `{api_url}`.
+- If `rag.health` fails, confirm the server is listening at `{api_url}`.
 - If the server starts but is not ready, check the LLM provider and embedding model.
-- If results are stale, run `rebuild_rag_index`.
+- If results are stale, run `rag.rebuild_index`.
 - Keep the old MCP in-process semantic tools disabled unless testing legacy behavior.
 """
 

--- a/obsidian_mcp/tools/registry.py
+++ b/obsidian_mcp/tools/registry.py
@@ -86,6 +86,9 @@ TOOL_SPECS: dict[str, ToolSpec] = {
     "move_note": ToolSpec(
         "Move Note", "notes_write", read_only=False, idempotent=False
     ),
+    "rename_note": ToolSpec(
+        "Rename Note", "notes_write", read_only=False, idempotent=False
+    ),
     "delete_note": ToolSpec(
         "Delete Note",
         "notes_write",
@@ -117,6 +120,7 @@ TOOL_SPECS: dict[str, ToolSpec] = {
     "get_notes_by_tag": ToolSpec("Get Notes By Tag", "vault_analysis"),
     "get_local_graph": ToolSpec("Get Local Graph", "vault_analysis"),
     "find_orphan_notes": ToolSpec("Find Orphan Notes", "vault_analysis"),
+    "find_broken_wikilinks": ToolSpec("Find Broken Wikilinks", "vault_analysis"),
     # Personal pack
     "quick_capture": ToolSpec(
         "Quick Capture",

--- a/obsidian_mcp/tools/registry.py
+++ b/obsidian_mcp/tools/registry.py
@@ -121,6 +121,12 @@ TOOL_SPECS: dict[str, ToolSpec] = {
     "get_local_graph": ToolSpec("Get Local Graph", "vault_analysis"),
     "find_orphan_notes": ToolSpec("Find Orphan Notes", "vault_analysis"),
     "find_broken_wikilinks": ToolSpec("Find Broken Wikilinks", "vault_analysis"),
+    "lint_vault": ToolSpec(
+        "Lint Vault",
+        "vault_analysis",
+        read_only=False,  # auto_fix=True writes files
+        idempotent=False,
+    ),
     # Personal pack
     "quick_capture": ToolSpec(
         "Quick Capture",

--- a/obsidian_mcp/tools/registry.py
+++ b/obsidian_mcp/tools/registry.py
@@ -38,66 +38,66 @@ class ToolSpec:
 
 TOOL_SPECS: dict[str, ToolSpec] = {
     # Core diagnostics and routing
-    "health_check": ToolSpec("Health Check"),
-    "diagnose_vault_setup": ToolSpec("Diagnose Vault Setup"),
-    "list_client_roots": ToolSpec("List Client Roots"),
-    "route_task": ToolSpec("Route Task"),
-    "read_vault_context": ToolSpec("Read Vault Context"),
+    "vault.health": ToolSpec("Health Check"),
+    "vault.diagnose": ToolSpec("Diagnose Vault Setup"),
+    "client.roots": ToolSpec("List Client Roots"),
+    "route.task": ToolSpec("Route Task"),
+    "vault.context": ToolSpec("Read Vault Context"),
     # Core navigation
-    "list_notes": ToolSpec("List Notes"),
-    "read_note": ToolSpec("Read Note"),
-    "search_notes": ToolSpec("Search Notes"),
-    "search_notes_by_date": ToolSpec("Search Notes By Date"),
-    "read_notes": ToolSpec("Read Multiple Notes"),
-    "get_note_info": ToolSpec("Get Note Info"),
-    "list_templates": ToolSpec("List Templates"),
-    "get_frontmatter": ToolSpec("Get Frontmatter"),
+    "notes.list": ToolSpec("List Notes"),
+    "notes.read": ToolSpec("Read Note"),
+    "notes.search": ToolSpec("Search Notes"),
+    "notes.search_by_date": ToolSpec("Search Notes By Date"),
+    "notes.read_many": ToolSpec("Read Multiple Notes"),
+    "notes.info": ToolSpec("Get Note Info"),
+    "templates.list": ToolSpec("List Templates"),
+    "notes.get_frontmatter": ToolSpec("Get Frontmatter"),
     # Core skills/resources
-    "list_skills": ToolSpec("List Skills"),
-    "read_skill": ToolSpec("Read Skill"),
-    "get_global_rules": ToolSpec("Get Global Rules"),
-    "validate_note": ToolSpec("Validate Note"),
+    "skills.list": ToolSpec("List Skills"),
+    "skills.read": ToolSpec("Read Skill"),
+    "rules.get": ToolSpec("Get Global Rules"),
+    "notes.validate": ToolSpec("Validate Note"),
     # Notes write pack
-    "suggest_note_location": ToolSpec(
+    "notes.suggest_location": ToolSpec(
         "Suggest Note Location", "notes_write", open_world=False
     ),
-    "create_note": ToolSpec(
+    "notes.create": ToolSpec(
         "Create Note", "notes_write", read_only=False, idempotent=False
     ),
-    "append_to_note": ToolSpec(
+    "notes.append": ToolSpec(
         "Append To Note", "notes_write", read_only=False, idempotent=False
     ),
-    "patch_note": ToolSpec(
+    "notes.patch": ToolSpec(
         "Patch Note", "notes_write", read_only=False, idempotent=False
     ),
-    "replace_note": ToolSpec(
+    "notes.replace": ToolSpec(
         "Replace Note",
         "notes_write",
         read_only=False,
         destructive=True,
         idempotent=False,
     ),
-    "update_frontmatter": ToolSpec(
+    "notes.update_frontmatter": ToolSpec(
         "Update Frontmatter", "notes_write", read_only=False, idempotent=False
     ),
-    "update_note_tags": ToolSpec(
+    "notes.update_tags": ToolSpec(
         "Update Note Tags", "notes_write", read_only=False, idempotent=False
     ),
-    "move_note": ToolSpec(
+    "notes.move": ToolSpec(
         "Move Note", "notes_write", read_only=False, idempotent=False
     ),
-    "rename_note": ToolSpec(
+    "notes.rename": ToolSpec(
         "Rename Note", "notes_write", read_only=False, idempotent=False
     ),
-    "delete_note": ToolSpec(
+    "notes.delete": ToolSpec(
         "Delete Note",
         "notes_write",
         read_only=False,
         destructive=True,
         idempotent=False,
     ),
-    "preview_replace_in_notes": ToolSpec("Preview Replace In Notes", "notes_write"),
-    "apply_replace_in_notes": ToolSpec(
+    "notes.preview_replace": ToolSpec("Preview Replace In Notes", "notes_write"),
+    "notes.apply_replace": ToolSpec(
         "Apply Replace In Notes",
         "notes_write",
         read_only=False,
@@ -105,91 +105,89 @@ TOOL_SPECS: dict[str, ToolSpec] = {
         idempotent=False,
     ),
     # Vault analysis pack
-    "get_vault_stats": ToolSpec("Get Vault Stats", "vault_analysis"),
-    "get_canonical_tags": ToolSpec("Get Canonical Tags", "vault_analysis"),
-    "analyze_tags": ToolSpec("Analyze Tags", "vault_analysis"),
-    "sync_tag_registry": ToolSpec(
+    "vault.stats": ToolSpec("Get Vault Stats", "vault_analysis"),
+    "tags.canonical": ToolSpec("Get Canonical Tags", "vault_analysis"),
+    "tags.analyze": ToolSpec("Analyze Tags", "vault_analysis"),
+    "tags.sync_registry": ToolSpec(
         "Sync Tag Registry", "vault_analysis", read_only=False, idempotent=False
     ),
-    "list_tags": ToolSpec("List Tags", "vault_analysis"),
-    "analyze_links": ToolSpec("Analyze Links", "vault_analysis"),
-    "summarize_recent_activity": ToolSpec(
-        "Summarize Recent Activity", "vault_analysis"
-    ),
-    "get_backlinks": ToolSpec("Get Backlinks", "vault_analysis"),
-    "get_notes_by_tag": ToolSpec("Get Notes By Tag", "vault_analysis"),
-    "get_local_graph": ToolSpec("Get Local Graph", "vault_analysis"),
-    "find_orphan_notes": ToolSpec("Find Orphan Notes", "vault_analysis"),
-    "find_broken_wikilinks": ToolSpec("Find Broken Wikilinks", "vault_analysis"),
-    "lint_vault": ToolSpec(
+    "tags.list": ToolSpec("List Tags", "vault_analysis"),
+    "links.analyze": ToolSpec("Analyze Links", "vault_analysis"),
+    "activity.recent": ToolSpec("Summarize Recent Activity", "vault_analysis"),
+    "links.backlinks": ToolSpec("Get Backlinks", "vault_analysis"),
+    "tags.notes_with": ToolSpec("Get Notes By Tag", "vault_analysis"),
+    "links.local_graph": ToolSpec("Get Local Graph", "vault_analysis"),
+    "links.find_orphans": ToolSpec("Find Orphan Notes", "vault_analysis"),
+    "links.find_broken": ToolSpec("Find Broken Wikilinks", "vault_analysis"),
+    "vault.lint": ToolSpec(
         "Lint Vault",
         "vault_analysis",
         read_only=False,  # auto_fix=True writes files
         idempotent=False,
     ),
     # Personal pack
-    "quick_capture": ToolSpec(
+    "inbox.capture": ToolSpec(
         "Quick Capture",
         "secundo_selebro",
         read_only=False,
         idempotent=False,
     ),
-    "random_concept": ToolSpec("Random Concept", "secundo_selebro"),
+    "random.concept": ToolSpec("Random Concept", "secundo_selebro"),
     # Agent administration pack
-    "refresh_skills_cache": ToolSpec("Refresh Skills Cache", "agents_admin"),
-    "create_skill": ToolSpec(
+    "skills.refresh_cache": ToolSpec("Refresh Skills Cache", "agents_admin"),
+    "skills.create": ToolSpec(
         "Create Skill", "agents_admin", read_only=False, idempotent=False
     ),
-    "suggest_vault_skills": ToolSpec("Suggest Vault Skills", "agents_admin"),
-    "sync_skills": ToolSpec(
+    "skills.suggest": ToolSpec("Suggest Vault Skills", "agents_admin"),
+    "skills.sync": ToolSpec(
         "Sync Skills", "agents_admin", read_only=False, idempotent=False
     ),
     # External packs
-    "get_youtube_transcript": ToolSpec(
+    "youtube.transcript": ToolSpec(
         "Get YouTube Transcript", "youtube", open_world=True
     ),
-    "rag_setup_status": ToolSpec("RAG Setup Status", "obsidianrag", open_world=True),
-    "rag_health": ToolSpec("RAG Health", "obsidianrag", open_world=True),
-    "ask_vault": ToolSpec("Ask Vault", "obsidianrag", open_world=True),
-    "rebuild_rag_index": ToolSpec(
+    "rag.setup_status": ToolSpec("RAG Setup Status", "obsidianrag", open_world=True),
+    "rag.health": ToolSpec("RAG Health", "obsidianrag", open_world=True),
+    "rag.ask": ToolSpec("Ask Vault", "obsidianrag", open_world=True),
+    "rag.rebuild_index": ToolSpec(
         "Rebuild RAG Index", "obsidianrag", read_only=False, idempotent=False
     ),
     # Legacy semantic pack
-    "semantic_search": ToolSpec(
+    "semantic.search": ToolSpec(
         "Legacy Semantic Search (Deprecated)", "legacy_semantic"
     ),
-    "index_vault_semantic": ToolSpec(
+    "semantic.index": ToolSpec(
         "Legacy Semantic Index (Deprecated)",
         "legacy_semantic",
         read_only=False,
         idempotent=False,
     ),
-    "suggest_semantic_connections": ToolSpec(
+    "semantic.suggest_connections": ToolSpec(
         "Legacy Semantic Connections (Deprecated)", "legacy_semantic"
     ),
     # Canvas pack
-    "canvas_read": ToolSpec("Read Canvas", "canvas"),
-    "canvas_list": ToolSpec("List Canvases", "canvas"),
-    "canvas_add_card": ToolSpec(
+    "canvas.read": ToolSpec("Read Canvas", "canvas"),
+    "canvas.list": ToolSpec("List Canvases", "canvas"),
+    "canvas.add_card": ToolSpec(
         "Add Canvas Card", "canvas", read_only=False, idempotent=False
     ),
-    "canvas_add_group": ToolSpec(
+    "canvas.add_group": ToolSpec(
         "Add Canvas Group", "canvas", read_only=False, idempotent=False
     ),
-    "canvas_add_edge": ToolSpec(
+    "canvas.add_edge": ToolSpec(
         "Add Canvas Edge", "canvas", read_only=False, idempotent=False
     ),
-    "canvas_update_card": ToolSpec(
+    "canvas.update_card": ToolSpec(
         "Update Canvas Card", "canvas", read_only=False, idempotent=False
     ),
-    "canvas_remove_card": ToolSpec(
+    "canvas.remove_card": ToolSpec(
         "Remove Canvas Card",
         "canvas",
         read_only=False,
         destructive=True,
         idempotent=False,
     ),
-    "canvas_remove_edge": ToolSpec(
+    "canvas.remove_edge": ToolSpec(
         "Remove Canvas Edge",
         "canvas",
         read_only=False,
@@ -197,38 +195,38 @@ TOOL_SPECS: dict[str, ToolSpec] = {
         idempotent=False,
     ),
     # Kanvas pack
-    "kanvas_status": ToolSpec("Kanvas Status", "kanvas"),
-    "kanvas_task": ToolSpec("Kanvas Task", "kanvas"),
-    "kanvas_ready": ToolSpec("Kanvas Ready Tasks", "kanvas"),
-    "kanvas_blocked": ToolSpec("Kanvas Blocked Tasks", "kanvas"),
-    "kanvas_start": ToolSpec(
+    "kanvas.status": ToolSpec("Kanvas Status", "kanvas"),
+    "kanvas.task": ToolSpec("Kanvas Task", "kanvas"),
+    "kanvas.ready": ToolSpec("Kanvas Ready Tasks", "kanvas"),
+    "kanvas.blocked": ToolSpec("Kanvas Blocked Tasks", "kanvas"),
+    "kanvas.start": ToolSpec(
         "Kanvas Start Task", "kanvas", read_only=False, idempotent=False
     ),
-    "kanvas_finish": ToolSpec(
+    "kanvas.finish": ToolSpec(
         "Kanvas Finish Task", "kanvas", read_only=False, idempotent=False
     ),
-    "kanvas_pause": ToolSpec(
+    "kanvas.pause": ToolSpec(
         "Kanvas Pause Task", "kanvas", read_only=False, idempotent=False
     ),
-    "kanvas_approve": ToolSpec(
+    "kanvas.approve": ToolSpec(
         "Kanvas Approve Task", "kanvas", read_only=False, idempotent=False
     ),
-    "kanvas_complete": ToolSpec(
+    "kanvas.complete": ToolSpec(
         "Kanvas Complete Task", "kanvas", read_only=False, idempotent=False
     ),
-    "kanvas_edit_task": ToolSpec(
+    "kanvas.edit_task": ToolSpec(
         "Kanvas Edit Task", "kanvas", read_only=False, idempotent=False
     ),
-    "kanvas_add_dependency": ToolSpec(
+    "kanvas.add_dependency": ToolSpec(
         "Kanvas Add Dependency", "kanvas", read_only=False, idempotent=False
     ),
-    "kanvas_propose_task": ToolSpec(
+    "kanvas.propose_task": ToolSpec(
         "Kanvas Propose Task", "kanvas", read_only=False, idempotent=False
     ),
-    "kanvas_propose_group": ToolSpec(
+    "kanvas.propose_group": ToolSpec(
         "Kanvas Propose Group", "kanvas", read_only=False, idempotent=False
     ),
-    "kanvas_init": ToolSpec("Kanvas Init", "kanvas", read_only=False, idempotent=False),
+    "kanvas.init": ToolSpec("Kanvas Init", "kanvas", read_only=False, idempotent=False),
 }
 
 

--- a/obsidian_mcp/tools/registry.py
+++ b/obsidian_mcp/tools/registry.py
@@ -56,6 +56,7 @@ TOOL_SPECS: dict[str, ToolSpec] = {
     "list_skills": ToolSpec("List Skills"),
     "read_skill": ToolSpec("Read Skill"),
     "get_global_rules": ToolSpec("Get Global Rules"),
+    "validate_note": ToolSpec("Validate Note"),
     # Notes write pack
     "suggest_note_location": ToolSpec(
         "Suggest Note Location", "notes_write", open_world=False

--- a/obsidian_mcp/tools/semantic.py
+++ b/obsidian_mcp/tools/semantic.py
@@ -32,7 +32,7 @@ def register_semantic_tools(mcp: FastMCP) -> None:
         # pylint: disable-next=import-outside-toplevel,unused-import
         import langchain  # noqa: F401
 
-        @register_tool(mcp, "semantic_search")
+        @register_tool(mcp, "semantic.search")
         async def semantic_search(
             query: str,
             metadata_filter: Optional[Dict[str, Any]] = None,
@@ -46,7 +46,7 @@ def register_semantic_tools(mcp: FastMCP) -> None:
             except Exception as e:  # pylint: disable=broad-exception-caught
                 return f"Error running semantic search: {e}"
 
-        @register_tool(mcp, "index_vault_semantic")
+        @register_tool(mcp, "semantic.index")
         async def index_vault_semantic(ctx, force: bool = False) -> str:
             """Update the legacy semantic index for the vault."""
             from .semantic_logic import index_semantic_vault
@@ -59,7 +59,7 @@ def register_semantic_tools(mcp: FastMCP) -> None:
             except Exception as e:  # pylint: disable=broad-exception-caught
                 return f"Error updating semantic index: {e}"
 
-        @register_tool(mcp, "suggest_semantic_connections")
+        @register_tool(mcp, "semantic.suggest_connections")
         async def suggest_semantic_connections(
             threshold: float = 0.70,
             limit: int = 5,
@@ -95,6 +95,6 @@ def _deprecated_result(result: str) -> str:
     """Prefix legacy semantic responses with a migration hint."""
     return (
         "Deprecated: `legacy_semantic` is maintained for backwards compatibility. "
-        "Prefer the `obsidianrag` tool set with `rag_health` and `ask_vault`.\n\n"
+        "Prefer the `obsidianrag` tool set with `rag.health` and `rag.ask`.\n\n"
         f"{result}"
     )

--- a/obsidian_mcp/tools/youtube.py
+++ b/obsidian_mcp/tools/youtube.py
@@ -10,7 +10,7 @@ from .registry import register_tool
 def register_youtube_tools(mcp: FastMCP) -> None:
     """Register YouTube tools."""
 
-    @register_tool(mcp, "get_youtube_transcript")
+    @register_tool(mcp, "youtube.transcript")
     def get_youtube_transcript(url: str, language: Optional[str] = None) -> str:
         """Fetch a YouTube transcript by URL or video ID."""
         from .youtube_logic import get_transcript_text

--- a/obsidian_mcp/utils/wikilinks.py
+++ b/obsidian_mcp/utils/wikilinks.py
@@ -1,0 +1,220 @@
+"""
+Wikilink scanning, resolution, and rewriting.
+
+Shared engine for issues #6 (find_broken_wikilinks), #7 (rename_note with
+link updates), and #11 (move_note unresolved-reference reporting).
+
+Naming: a "wikilink" follows Obsidian syntax — ``[[Target]]``,
+``[[Target|alias]]``, ``[[Target#Section]]``. Image/file embeds
+``![[file.png]]`` are intentionally excluded; they aren't note-to-note
+edges and aren't covered by ``rename_note``.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+# Match [[...]] but NOT ![[...]] (embeds). The negative lookbehind keeps
+# the regex simple while filtering image/file transclusions.
+WIKILINK_RE = re.compile(r"(?<!\!)\[\[([^\]\n]+?)\]\]")
+
+
+@dataclass(frozen=True)
+class WikilinkOccurrence:
+    """A single ``[[...]]`` occurrence in a vault file."""
+
+    source: Path
+    line_no: int
+    raw: str  # full bracket contents, e.g. "Note Name|alias"
+    target: str  # the resolution target, e.g. "Note Name"
+    alias: str | None
+    section: str | None
+
+    def reconstruct(self, new_target: str) -> str:
+        """Build the replacement bracket contents preserving alias/section."""
+        out = new_target
+        if self.section:
+            out += f"#{self.section}"
+        if self.alias is not None:
+            out += f"|{self.alias}"
+        return out
+
+
+@dataclass(frozen=True)
+class BrokenWikilink:
+    """A wikilink whose target stem doesn't exist in the vault."""
+
+    occurrence: WikilinkOccurrence
+    suggestions: tuple[str, ...]  # candidate existing stems, by similarity desc
+
+
+def parse_wikilink(raw: str) -> tuple[str, str | None, str | None]:
+    """Split ``raw`` (contents between ``[[`` and ``]]``) into target/section/alias."""
+    alias: str | None = None
+    section: str | None = None
+    body = raw.strip()
+    if "|" in body:
+        body, alias_part = body.split("|", 1)
+        alias = alias_part.strip()
+        body = body.strip()
+    if "#" in body:
+        body, section_part = body.split("#", 1)
+        section = section_part.strip()
+        body = body.strip()
+    return body, section, alias
+
+
+def iter_wikilinks(content: str, source: Path) -> Iterable[WikilinkOccurrence]:
+    """Yield every wikilink in ``content`` with its line number."""
+    for line_no, line in enumerate(content.splitlines(), start=1):
+        for match in WIKILINK_RE.finditer(line):
+            raw = match.group(1)
+            target, section, alias = parse_wikilink(raw)
+            if not target:
+                continue
+            yield WikilinkOccurrence(
+                source=source,
+                line_no=line_no,
+                raw=raw,
+                target=target,
+                alias=alias,
+                section=section,
+            )
+
+
+def build_stem_index(vault_path: Path) -> dict[str, list[Path]]:
+    """Map note stems (basename without ``.md``) to one or more vault paths.
+
+    A stem can map to multiple paths when the vault has duplicate
+    filenames in different folders; Obsidian itself disambiguates by
+    full path, but for broken-link detection any match counts as
+    resolution.
+    """
+    index: dict[str, list[Path]] = {}
+    for md_file in vault_path.rglob("*.md"):
+        stem = md_file.stem
+        index.setdefault(stem, []).append(md_file)
+    return index
+
+
+def target_resolves(
+    target: str, stem_index: dict[str, list[Path]], vault_path: Path
+) -> bool:
+    """Return True iff ``target`` matches an existing note.
+
+    Resolution rules (in order):
+    1. ``target`` is a full vault-relative path with ``.md`` -> file must exist.
+    2. ``target`` is a bare stem -> stem index hit.
+    3. ``target`` contains ``/`` (folder/Stem) -> resolve as ``<vault>/<target>.md``.
+    """
+    if target.endswith(".md"):
+        candidate = vault_path / target
+        return candidate.exists()
+    if "/" in target:
+        candidate = vault_path / f"{target}.md"
+        return candidate.exists()
+    return target in stem_index
+
+
+def suggest_targets(
+    target: str, stem_index: dict[str, list[Path]], limit: int = 3, cutoff: float = 0.6
+) -> tuple[str, ...]:
+    """Use difflib to find existing stems that are close to ``target``."""
+    needle = target.split("/")[-1]
+    stems = list(stem_index.keys())
+    matches = difflib.get_close_matches(needle, stems, n=limit, cutoff=cutoff)
+    return tuple(matches)
+
+
+def scan_broken_wikilinks(vault_path: Path) -> list[BrokenWikilink]:
+    """Walk the vault and return every wikilink that can't be resolved."""
+    stem_index = build_stem_index(vault_path)
+    broken: list[BrokenWikilink] = []
+    for md_file in vault_path.rglob("*.md"):
+        try:
+            content = md_file.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for occ in iter_wikilinks(content, md_file):
+            if target_resolves(occ.target, stem_index, vault_path):
+                continue
+            broken.append(
+                BrokenWikilink(
+                    occurrence=occ,
+                    suggestions=suggest_targets(occ.target, stem_index),
+                )
+            )
+    return broken
+
+
+def rewrite_wikilinks_in_content(
+    content: str,
+    *,
+    old_target: str,
+    new_target: str,
+) -> tuple[str, int]:
+    """Replace every ``[[old_target...]]`` with ``[[new_target...]]``.
+
+    Aliases and sections are preserved (``[[X|alias]]`` -> ``[[Y|alias]]``,
+    ``[[X#Section]]`` -> ``[[Y#Section]]``). Comparison is case-sensitive
+    because Obsidian filenames are case-sensitive on Linux/macOS.
+
+    Returns ``(new_content, replacement_count)``.
+    """
+    if old_target == new_target:
+        return content, 0
+
+    count = 0
+
+    def _replace(match: re.Match) -> str:
+        nonlocal count
+        raw = match.group(1)
+        target, section, alias = parse_wikilink(raw)
+        if target != old_target:
+            return match.group(0)
+        count += 1
+        replacement = new_target
+        if section:
+            replacement += f"#{section}"
+        if alias is not None:
+            replacement += f"|{alias}"
+        return f"[[{replacement}]]"
+
+    new_content = WIKILINK_RE.sub(_replace, content)
+    return new_content, count
+
+
+def rewrite_wikilinks_in_vault(
+    vault_path: Path,
+    *,
+    old_target: str,
+    new_target: str,
+    dry_run: bool = False,
+) -> tuple[int, list[Path]]:
+    """Update every wikilink across the vault that points to ``old_target``.
+
+    Returns ``(total_replacements, list_of_touched_files)``. When
+    ``dry_run`` is True, no files are written; the return values still
+    reflect what would change.
+    """
+    total = 0
+    touched: list[Path] = []
+    for md_file in vault_path.rglob("*.md"):
+        try:
+            content = md_file.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        new_content, count = rewrite_wikilinks_in_content(
+            content, old_target=old_target, new_target=new_target
+        )
+        if count == 0:
+            continue
+        total += count
+        touched.append(md_file)
+        if not dry_run:
+            md_file.write_text(new_content, encoding="utf-8")
+    return total, touched

--- a/obsidian_mcp/utils/wikilinks.py
+++ b/obsidian_mcp/utils/wikilinks.py
@@ -7,7 +7,7 @@ link updates), and #11 (move_note unresolved-reference reporting).
 Naming: a "wikilink" follows Obsidian syntax — ``[[Target]]``,
 ``[[Target|alias]]``, ``[[Target#Section]]``. Image/file embeds
 ``![[file.png]]`` are intentionally excluded; they aren't note-to-note
-edges and aren't covered by ``rename_note``.
+edges and aren't covered by ``notes.rename``.
 """
 
 from __future__ import annotations

--- a/tests/canvas/test_integration.py
+++ b/tests/canvas/test_integration.py
@@ -108,33 +108,33 @@ class TestProjectLifecycle:
         tool_names = [t.name for t in asyncio.run(mcp.list_tools())]
 
         canvas_tools = [
-            "canvas_read",
-            "canvas_list",
-            "canvas_add_card",
-            "canvas_add_group",
-            "canvas_add_edge",
-            "canvas_update_card",
-            "canvas_remove_card",
-            "canvas_remove_edge",
+            "canvas.read",
+            "canvas.list",
+            "canvas.add_card",
+            "canvas.add_group",
+            "canvas.add_edge",
+            "canvas.update_card",
+            "canvas.remove_card",
+            "canvas.remove_edge",
         ]
         for tool in canvas_tools:
             assert tool in tool_names, f"Missing canvas tool: {tool}"
 
         kanvas_tools = [
-            "kanvas_status",
-            "kanvas_task",
-            "kanvas_ready",
-            "kanvas_blocked",
-            "kanvas_start",
-            "kanvas_finish",
-            "kanvas_pause",
-            "kanvas_approve",
-            "kanvas_complete",
-            "kanvas_edit_task",
-            "kanvas_add_dependency",
-            "kanvas_propose_task",
-            "kanvas_propose_group",
-            "kanvas_init",
+            "kanvas.status",
+            "kanvas.task",
+            "kanvas.ready",
+            "kanvas.blocked",
+            "kanvas.start",
+            "kanvas.finish",
+            "kanvas.pause",
+            "kanvas.approve",
+            "kanvas.complete",
+            "kanvas.edit_task",
+            "kanvas.add_dependency",
+            "kanvas.propose_task",
+            "kanvas.propose_group",
+            "kanvas.init",
         ]
         for tool in kanvas_tools:
             assert tool in tool_names, f"Missing kanvas tool: {tool}"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -27,13 +27,13 @@ def test_agent_tools_registration(mock_valid_vault):
     """Verify that agent tools are registered in the server."""
     mcp = create_server()
     tool_names = _get_tool_names(mcp)
-    assert "list_skills" in tool_names
-    assert "read_skill" in tool_names
-    assert "get_global_rules" in tool_names
+    assert "skills.list" in tool_names
+    assert "skills.read" in tool_names
+    assert "rules.get" in tool_names
 
 
 def test_navigation_move_registration(mock_valid_vault):
     """Verify that move_note is registered when notes_write is enabled."""
     mcp = create_server()
     tool_names = _get_tool_names(mcp)
-    assert "move_note" in tool_names
+    assert "notes.move" in tool_names

--- a/tests/test_confirmation_flow.py
+++ b/tests/test_confirmation_flow.py
@@ -1,0 +1,39 @@
+"""Tests for elicit-based confirmation flow.
+
+Issue #1: cancellation must surface a specific reason instead of opaque
+"Operation cancelled.", and the unsupported-client path must be distinct
+from the user-declined / user-dismissed paths.
+"""
+
+from obsidian_mcp.messages import ERRORS
+from obsidian_mcp.tools.creation import _cancellation_reason
+
+
+class TestCancellationReason:
+    def test_decline_returns_explicit_rejection_message(self):
+        msg = _cancellation_reason("decline")
+        assert msg == ERRORS.OPERATION_DECLINED
+        assert "rechazo" in msg
+
+    def test_cancel_returns_dismissed_message(self):
+        msg = _cancellation_reason("cancel")
+        assert msg == ERRORS.OPERATION_DISMISSED
+        assert "cerro" in msg
+
+    def test_unknown_action_falls_back_to_decline(self):
+        msg = _cancellation_reason("weirdo_value")
+        assert msg == ERRORS.OPERATION_DECLINED
+
+    def test_messages_are_all_in_spanish(self):
+        """Issue #13: no English in confirmation errors."""
+        for msg in (
+            ERRORS.OPERATION_DECLINED,
+            ERRORS.OPERATION_DISMISSED,
+            ERRORS.OPERATION_CANCELLED_NO_CONFIRM,
+        ):
+            assert "cancelled" not in msg.lower()
+            assert "operation" not in msg.lower()
+
+    def test_unsupported_host_message_hints_at_workaround(self):
+        """Agents should know they can fall back to preview_replace_in_notes."""
+        assert "preview_replace_in_notes" in ERRORS.OPERATION_CANCELLED_NO_CONFIRM

--- a/tests/test_create_note.py
+++ b/tests/test_create_note.py
@@ -1,0 +1,156 @@
+"""Tests for create_note logic, focused on frontmatter merging.
+
+Issue #2: when the `content` arg already includes a YAML frontmatter block,
+fields like `type`/`status` from the embedded frontmatter must survive.
+"""
+
+import re
+
+import pytest
+import yaml
+
+from obsidian_mcp.tools.creation_logic import create_note
+
+
+@pytest.fixture
+def temp_vault(tmp_path, monkeypatch):
+    """Create a temp vault and patch the vault path."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    monkeypatch.setattr(
+        "obsidian_mcp.tools.creation_logic.get_vault_path",
+        lambda: vault,
+    )
+    monkeypatch.setattr(
+        "obsidian_mcp.tools.creation_logic.get_vault_config",
+        lambda *_args, **_kwargs: None,
+    )
+    return vault
+
+
+def _read_frontmatter(note_path):
+    """Pull YAML frontmatter dict out of a written note."""
+    raw = note_path.read_text(encoding="utf-8")
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n", raw, re.DOTALL)
+    assert match, f"No frontmatter in {note_path}: {raw[:200]}"
+    return yaml.safe_load(match.group(1))
+
+
+class TestCreateNoteFrontmatterMerge:
+    """Issue #2: embedded frontmatter must not be stripped by tool-generated one."""
+
+    def test_embedded_type_and_status_are_preserved(self, temp_vault):
+        embedded = (
+            "---\n"
+            "title: X\n"
+            "type: recurso\n"
+            "status: completo\n"
+            "tags: [astro, equipo]\n"
+            "---\n\n"
+            "# X\n\nbody\n"
+        )
+        result = create_note(
+            titulo="X",
+            contenido=embedded,
+            carpeta="notes",
+            etiquetas="",
+        )
+        assert result.success
+
+        fm = _read_frontmatter(temp_vault / "notes" / "X.md")
+        assert fm["type"] == "recurso"
+        assert fm["status"] == "completo"
+        assert fm["title"] == "X"
+
+    def test_embedded_custom_fields_survive(self, temp_vault):
+        embedded = (
+            "---\n"
+            "title: Y\n"
+            "type: nota\n"
+            "status: captura\n"
+            "related: ['[[Otra nota]]']\n"
+            "rating: 5\n"
+            "---\n\nbody\n"
+        )
+        result = create_note(
+            titulo="Y",
+            contenido=embedded,
+            carpeta="notes",
+            etiquetas="",
+        )
+        assert result.success
+
+        fm = _read_frontmatter(temp_vault / "notes" / "Y.md")
+        assert fm["related"] == ["[[Otra nota]]"]
+        assert fm["rating"] == 5
+
+    def test_parameter_tags_merge_with_embedded_tags(self, temp_vault):
+        embedded = (
+            "---\ntitle: Z\ntype: nota\nstatus: captura\ntags: [astro]\n---\n\nbody\n"
+        )
+        result = create_note(
+            titulo="Z",
+            contenido=embedded,
+            carpeta="notes",
+            etiquetas="equipo, fotografia",
+        )
+        assert result.success
+
+        fm = _read_frontmatter(temp_vault / "notes" / "Z.md")
+        assert set(fm["tags"]) == {"astro", "equipo", "fotografia"}
+
+    def test_embedded_title_wins_over_parameter_title(self, temp_vault):
+        """When both are present, embedded title is the source of truth.
+
+        The filename still comes from the `titulo` parameter (the
+        sanitization happens in the call), but the frontmatter title
+        should reflect the author's embedded value.
+        """
+        embedded = (
+            "---\ntitle: Titulo Embebido\ntype: nota\nstatus: captura\n---\n\nbody\n"
+        )
+        result = create_note(
+            titulo="ParamTitle",
+            contenido=embedded,
+            carpeta="notes",
+            etiquetas="",
+        )
+        assert result.success
+
+        fm = _read_frontmatter(temp_vault / "notes" / "ParamTitle.md")
+        assert fm["title"] == "Titulo Embebido"
+
+    def test_embedded_created_date_is_preserved(self, temp_vault):
+        embedded = (
+            "---\n"
+            "title: Histo\n"
+            "type: nota\n"
+            "status: captura\n"
+            "created: '2020-01-15'\n"
+            "---\n\nbody\n"
+        )
+        result = create_note(
+            titulo="Histo",
+            contenido=embedded,
+            carpeta="notes",
+            etiquetas="",
+        )
+        assert result.success
+
+        fm = _read_frontmatter(temp_vault / "notes" / "Histo.md")
+        assert str(fm["created"]) == "2020-01-15"
+
+    def test_no_embedded_frontmatter_falls_back_to_params(self, temp_vault):
+        """When content has no frontmatter, build one from parameters."""
+        result = create_note(
+            titulo="Plain",
+            contenido="body without frontmatter\n",
+            carpeta="notes",
+            etiquetas="one, two",
+        )
+        assert result.success
+
+        fm = _read_frontmatter(temp_vault / "notes" / "Plain.md")
+        assert fm["title"] == "Plain"
+        assert set(fm["tags"]) == {"one", "two"}
+        assert "created" in fm

--- a/tests/test_edit_note.py
+++ b/tests/test_edit_note.py
@@ -192,6 +192,41 @@ class TestEditNoteAtomicFailure:
         assert "No se encontro" in result.error
         assert sample_note.read_text(encoding="utf-8") == original  # unchanged
 
+    def test_old_not_found_suggests_close_matches(self, temp_vault, monkeypatch):
+        """Issue #8: emoji codepoint mismatch should surface fuzzy suggestions."""
+        note = temp_vault / "shop.md"
+        note.write_text(
+            "---\ntitle: Shop\n---\n\n## \U0001f6d2 Recomendaciones de Compra\n\nx\n",
+            encoding="utf-8",
+        )
+        _patch_vault(monkeypatch, temp_vault)
+        # Couch emoji 1F6CB vs cart emoji 1F6D2 -- one codepoint off.
+        result = edit_note(
+            "shop.md",
+            [
+                {
+                    "old": "## \U0001f6cb Recomendaciones de Compra",
+                    "new": "## Compra",
+                }
+            ],
+        )
+        assert not result.success
+        assert "No se encontro" in result.error
+        assert "Quiza quisiste decir" in result.error
+        assert "Recomendaciones de Compra" in result.error
+
+    def test_old_not_found_without_close_matches_omits_hint(
+        self, temp_vault, sample_note, monkeypatch
+    ):
+        """If nothing nearby is similar, don't fabricate suggestions."""
+        _patch_vault(monkeypatch, temp_vault)
+        result = edit_note(
+            "test_note.md",
+            [{"old": "ZZZZZZ totally unrelated 9999 quasar", "new": "x"}],
+        )
+        assert not result.success
+        assert "Quiza quisiste decir" not in (result.error or "")
+
     def test_old_appears_multiple_times(self, temp_vault, monkeypatch):
         """Fail if old text appears more than once (ambiguity)."""
         note = temp_vault / "dup.md"

--- a/tests/test_lint_vault.py
+++ b/tests/test_lint_vault.py
@@ -1,0 +1,195 @@
+"""Tests for lint_vault and the auto_fix engine (Issue #9)."""
+
+import pytest
+
+from obsidian_mcp.config import reset_settings
+from obsidian_mcp.middleware import (
+    apply_autofix,
+    invalidate_rules_cache,
+    is_rule_autofixable,
+)
+from obsidian_mcp.tools.analysis_logic import lint_vault
+
+RULES_FILE = """\
+---
+name: reglas-test
+validations:
+  - id: no_emoji_headings
+    applies_to: [create, append, edit]
+    scope: headings
+    pattern: "[\\U0001F300-\\U0001FFFF]"
+    warning: "Emojis en cabeceras"
+  - id: required_frontmatter
+    applies_to: [create]
+    scope: frontmatter
+    required_fields: [type, status]
+    warning: "Frontmatter incompleto: faltan {missing_fields}"
+---
+
+# Reglas
+"""
+
+
+@pytest.fixture
+def vault_with_rules(tmp_path, monkeypatch):
+    v = tmp_path / "vault"
+    v.mkdir()
+    (v / ".agents").mkdir()
+    (v / ".agents" / "REGLAS_GLOBALES.md").write_text(RULES_FILE, encoding="utf-8")
+
+    # Clean note
+    (v / "clean.md").write_text(
+        "---\ntype: nota\nstatus: captura\n---\n\n## Clean Heading\nbody\n",
+        encoding="utf-8",
+    )
+    # Emoji in heading
+    (v / "emoji.md").write_text(
+        "---\ntype: nota\nstatus: captura\n---\n\n## \U0001f680 Rocket Heading\nbody\n",
+        encoding="utf-8",
+    )
+    # Missing frontmatter fields
+    (v / "no_fm.md").write_text(
+        "---\ntitle: x\n---\n\n## OK Heading\nbody\n", encoding="utf-8"
+    )
+
+    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(v))
+    reset_settings()
+    invalidate_rules_cache()
+    return v
+
+
+class TestApplyAutofix:
+    def test_strips_emoji_from_heading(self):
+        rule = {
+            "id": "no_emoji_headings",
+            "scope": "headings",
+            "pattern": "[\U0001f300-\U0001ffff]",
+            "warning": "x",
+        }
+        content = "## \U0001f680 Title\nbody\n## clean\n"
+        new, count = apply_autofix(rule, content)
+        assert count == 1
+        assert "\U0001f680" not in new
+        assert "## Title" in new
+        assert "## clean" in new  # untouched
+
+    def test_does_not_touch_body_for_heading_rule(self):
+        rule = {
+            "id": "no_emoji_headings",
+            "scope": "headings",
+            "pattern": "[\U0001f300-\U0001ffff]",
+            "warning": "x",
+        }
+        content = "## clean\nbody with \U0001f680 emoji\n"
+        new, count = apply_autofix(rule, content)
+        assert count == 0
+        assert "\U0001f680" in new
+
+    def test_body_scope_strips_anywhere(self):
+        rule = {
+            "id": "no_tags_inline",
+            "scope": "body",
+            "pattern": "#tag\\w+",
+            "warning": "x",
+        }
+        content = "hello #tag1 world #tag2\n"
+        new, count = apply_autofix(rule, content)
+        assert count == 2
+        assert "#tag" not in new
+
+    def test_not_autofixable_for_frontmatter_rule(self):
+        rule = {
+            "id": "required_frontmatter",
+            "scope": "frontmatter",
+            "required_fields": ["type"],
+            "warning": "x",
+        }
+        assert not is_rule_autofixable(rule)
+        new, count = apply_autofix(rule, "## x\n")
+        assert count == 0
+        assert new == "## x\n"
+
+
+class TestLintVault:
+    def test_reports_violations_grouped_by_file(self, vault_with_rules):
+        result = lint_vault()
+        assert result.success
+        text = result.data
+        assert "emoji.md" in text
+        assert "no_fm.md" in text
+        assert "clean.md" not in text  # no violations
+        assert "no_emoji_headings" in text
+        assert "required_frontmatter" in text
+
+    def test_clean_vault_returns_zero(self, tmp_path, monkeypatch):
+        v = tmp_path / "vault"
+        v.mkdir()
+        (v / ".agents").mkdir()
+        (v / ".agents" / "REGLAS_GLOBALES.md").write_text(RULES_FILE, encoding="utf-8")
+        (v / "fine.md").write_text(
+            "---\ntype: nota\nstatus: captura\n---\n\n## fine\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(v))
+        reset_settings()
+        invalidate_rules_cache()
+        result = lint_vault()
+        assert result.success
+        assert "0 violaciones" in result.data
+
+    def test_auto_fix_writes_changes(self, vault_with_rules):
+        original = (vault_with_rules / "emoji.md").read_text(encoding="utf-8")
+        assert "\U0001f680" in original
+
+        result = lint_vault(auto_fix=True)
+        assert result.success
+        assert "Auto-fix aplicado" in result.data
+
+        new_content = (vault_with_rules / "emoji.md").read_text(encoding="utf-8")
+        assert "\U0001f680" not in new_content
+
+    def test_auto_fix_does_not_alter_frontmatter_rule_target(self, vault_with_rules):
+        """no_fm.md is missing frontmatter fields -- not autofixable, must stay as-is."""
+        original = (vault_with_rules / "no_fm.md").read_text(encoding="utf-8")
+        lint_vault(auto_fix=True)
+        # Heading rule didn't apply (already clean), frontmatter rule not autofixed
+        new = (vault_with_rules / "no_fm.md").read_text(encoding="utf-8")
+        assert new == original
+
+    def test_dry_run_does_not_write(self, vault_with_rules):
+        original = (vault_with_rules / "emoji.md").read_text(encoding="utf-8")
+        result = lint_vault(auto_fix=False)
+        assert result.success
+        assert "Auto-fix" not in result.data  # not reported in dry run
+        new = (vault_with_rules / "emoji.md").read_text(encoding="utf-8")
+        assert new == original
+
+    def test_folder_scopes_scan(self, vault_with_rules):
+        sub = vault_with_rules / "sub"
+        sub.mkdir()
+        (sub / "ok.md").write_text(
+            "---\ntype: nota\nstatus: captura\n---\n\n## clean\n",
+            encoding="utf-8",
+        )
+        result = lint_vault(folder="sub")
+        assert result.success
+        assert "0 violaciones" in result.data
+        # Whole-vault scan still sees the emoji.md
+        all_result = lint_vault()
+        assert "emoji.md" in all_result.data
+
+    def test_rule_id_filter(self, vault_with_rules):
+        result = lint_vault(rule_ids=["no_emoji_headings"])
+        assert result.success
+        text = result.data
+        assert "no_emoji_headings" in text
+        assert "required_frontmatter" not in text
+
+    def test_unknown_rule_id_errors(self, vault_with_rules):
+        result = lint_vault(rule_ids=["totally_made_up"])
+        assert not result.success
+        assert "REGLAS_GLOBALES" in (result.error or "")
+
+    def test_negative_limit_rejected(self, vault_with_rules):
+        result = lint_vault(limit=-1)
+        assert not result.success

--- a/tests/test_list_notes_pagination.py
+++ b/tests/test_list_notes_pagination.py
@@ -1,0 +1,93 @@
+"""Tests for list_notes pagination, filtering, and limits (Issue #5)."""
+
+import pytest
+
+from obsidian_mcp.config import reset_settings
+from obsidian_mcp.tools.navigation_logic import list_notes
+
+
+@pytest.fixture
+def populated_vault(tmp_path, monkeypatch):
+    """Vault with 25 notes across two folders for pagination tests."""
+    vault = tmp_path / "vault"
+    (vault / "a").mkdir(parents=True)
+    (vault / "b").mkdir(parents=True)
+    for i in range(15):
+        (vault / "a" / f"note-{i:02d}.md").write_text(
+            f"# Note {i}\nbody\n", encoding="utf-8"
+        )
+    for i in range(10):
+        (vault / "b" / f"note-{i:02d}.md").write_text(
+            f"# B Note {i}\nbody\n", encoding="utf-8"
+        )
+    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+    reset_settings()
+    return vault
+
+
+class TestListNotesPagination:
+    def test_default_returns_all_when_below_limit(self, populated_vault):
+        result = list_notes()
+        assert result.success
+        assert "25 total" in result.data
+        assert "showing 1-25" in result.data
+        assert "Truncated" not in result.data
+
+    def test_limit_caps_results(self, populated_vault):
+        result = list_notes(limit=10)
+        assert result.success
+        assert "25 total" in result.data
+        assert "showing 1-10" in result.data
+        assert "15 more notes available" in result.data
+        assert "offset=10" in result.data
+
+    def test_offset_skips_initial_results(self, populated_vault):
+        result = list_notes(offset=20, limit=10)
+        assert result.success
+        assert "showing 21-25" in result.data
+        assert "Truncated" not in result.data
+
+    def test_limit_zero_means_no_limit(self, populated_vault):
+        result = list_notes(limit=0)
+        assert result.success
+        assert "25 total" in result.data
+        assert "Truncated" not in result.data
+
+    def test_folder_filter(self, populated_vault):
+        result = list_notes(carpeta="a")
+        assert result.success
+        assert "15 total" in result.data
+
+    def test_pattern_filter(self, populated_vault):
+        """Issue #5: glob pattern to narrow results."""
+        result = list_notes(pattern="note-0?.md")
+        assert result.success
+        # note-00..note-09 in both folders = 20 matches, but folder b only has 0-9 (10),
+        # folder a has 0-9 (10) = 20 total.
+        assert "20 total" in result.data
+
+    def test_pattern_and_folder_combined(self, populated_vault):
+        result = list_notes(carpeta="b", pattern="note-0?.md")
+        assert result.success
+        assert "10 total" in result.data
+
+    def test_negative_limit_rejected(self, populated_vault):
+        result = list_notes(limit=-1)
+        assert not result.success
+        assert "limit" in (result.error or "")
+
+    def test_negative_offset_rejected(self, populated_vault):
+        result = list_notes(offset=-5)
+        assert not result.success
+        assert "offset" in (result.error or "")
+
+    def test_offset_past_end_returns_empty_page_message(self, populated_vault):
+        result = list_notes(offset=100, limit=10)
+        assert result.success
+        assert "No notes in this page" in result.data
+        assert "Total visibles: 25" in result.data
+
+    def test_nonexistent_folder(self, populated_vault):
+        result = list_notes(carpeta="zzz")
+        assert not result.success
+        assert "does not exist" in (result.error or "")

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -244,18 +244,19 @@ class TestEnrichResponse:
         assert "[WARNINGS:" in result
         assert "Emojis en cabeceras" in result
 
-    def test_injects_prose_for_creation_tools(self, rules_file):
+    def test_injects_prose_only_when_violations_for_creation_tools(self, rules_file):
+        """Issue #3: full prose only emitted when there are warnings."""
         invalidate_rules_cache()
         with patch("obsidian_mcp.middleware.get_vault_path", return_value=rules_file):
-            result = enrich_response(
+            with_violations = enrich_response(
                 tool_name="create_note",
                 result="Nota creada: test.md",
-                title="Mi nota",
-                content="## Limpio\n\nTexto",
+                title="\U0001f680 Mi nota",
+                content="## \U0001f680 Cabecera\n\nTexto",
                 frontmatter={"type": "apunte", "status": "captura", "tags": ["test"]},
             )
-        assert "[REGLAS ACTIVAS DEL VAULT]" in result
-        assert "Reglas Globales para Agentes" in result
+        assert "[REGLAS ACTIVAS DEL VAULT]" in with_violations
+        assert "Reglas Globales para Agentes" in with_violations
 
     def test_no_prose_injection_for_edit_tool(self, rules_file):
         invalidate_rules_cache()
@@ -278,7 +279,8 @@ class TestEnrichResponse:
             )
         assert "[REGLAS ACTIVAS DEL VAULT]" not in result
 
-    def test_clean_result_when_no_violations_still_gets_prose(self, rules_file):
+    def test_clean_result_gets_compact_hint_not_full_prose(self, rules_file):
+        """Issue #3: clean creates omit the ~2KB prose dump and emit a compact pointer."""
         invalidate_rules_cache()
         with patch("obsidian_mcp.middleware.get_vault_path", return_value=rules_file):
             result = enrich_response(
@@ -287,4 +289,79 @@ class TestEnrichResponse:
                 content="Texto normal sin problemas",
             )
         assert "[WARNINGS:" not in result
-        assert "[REGLAS ACTIVAS DEL VAULT]" in result
+        assert "[REGLAS ACTIVAS DEL VAULT]" not in result
+        assert "get_global_rules()" in result
+
+
+class TestValidateNoteTool:
+    """Issue #10: pre-flight validation tool."""
+
+    def test_clean_note_returns_valid_true(self, rules_file):
+        import json
+
+        from obsidian_mcp.tools.agents_logic import validate_note_logic
+
+        invalidate_rules_cache()
+        with patch("obsidian_mcp.middleware.get_vault_path", return_value=rules_file):
+            result = validate_note_logic(
+                title="Mi nota",
+                content=(
+                    "---\n"
+                    "type: apunte\n"
+                    "status: captura\n"
+                    "tags: [test]\n"
+                    "---\n\n"
+                    "## Seccion limpia\n\nTexto"
+                ),
+                mode="create",
+            )
+        assert result.success
+        payload = json.loads(result.data)
+        assert payload["valid"] is True
+        assert payload["violations"] == []
+
+    def test_emoji_in_heading_returns_violation(self, rules_file):
+        import json
+
+        from obsidian_mcp.tools.agents_logic import validate_note_logic
+
+        invalidate_rules_cache()
+        with patch("obsidian_mcp.middleware.get_vault_path", return_value=rules_file):
+            result = validate_note_logic(
+                title="Mi nota",
+                content=(
+                    "---\n"
+                    "type: apunte\n"
+                    "status: captura\n"
+                    "tags: [test]\n"
+                    "---\n\n"
+                    "## \U0001f680 Cabecera con emoji\n"
+                ),
+                mode="create",
+            )
+        payload = json.loads(result.data)
+        assert payload["valid"] is False
+        assert any("Emojis en cabeceras" in v for v in payload["violations"])
+
+    def test_missing_frontmatter_reports_missing_fields(self, rules_file):
+        import json
+
+        from obsidian_mcp.tools.agents_logic import validate_note_logic
+
+        invalidate_rules_cache()
+        with patch("obsidian_mcp.middleware.get_vault_path", return_value=rules_file):
+            result = validate_note_logic(
+                title="Mi nota",
+                content="# Sin frontmatter",
+                mode="create",
+            )
+        payload = json.loads(result.data)
+        assert payload["valid"] is False
+        assert any("type" in v for v in payload["violations"])
+
+    def test_invalid_mode_returns_error(self):
+        from obsidian_mcp.tools.agents_logic import validate_note_logic
+
+        result = validate_note_logic(content="x", mode="totally_invalid")
+        assert not result.success
+        assert "mode" in result.error

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -226,7 +226,7 @@ class TestRunValidations:
 class TestEnrichResponse:
     def test_passthrough_for_unknown_tool(self):
         result = enrich_response(
-            tool_name="read_note",
+            tool_name="notes.read",
             result="nota leida",
         )
         assert result == "nota leida"
@@ -235,7 +235,7 @@ class TestEnrichResponse:
         invalidate_rules_cache()
         with patch("obsidian_mcp.middleware.get_vault_path", return_value=rules_file):
             result = enrich_response(
-                tool_name="create_note",
+                tool_name="notes.create",
                 result="Nota creada: test.md",
                 title="\U0001f680 Mi nota",
                 content="## \U0001f680 Cabecera\n\nTexto",
@@ -249,7 +249,7 @@ class TestEnrichResponse:
         invalidate_rules_cache()
         with patch("obsidian_mcp.middleware.get_vault_path", return_value=rules_file):
             with_violations = enrich_response(
-                tool_name="create_note",
+                tool_name="notes.create",
                 result="Nota creada: test.md",
                 title="\U0001f680 Mi nota",
                 content="## \U0001f680 Cabecera\n\nTexto",
@@ -262,7 +262,7 @@ class TestEnrichResponse:
         invalidate_rules_cache()
         with patch("obsidian_mcp.middleware.get_vault_path", return_value=rules_file):
             result = enrich_response(
-                tool_name="patch_note",
+                tool_name="notes.patch",
                 result="Nota editada",
                 content="## Limpio\n\nTexto",
             )
@@ -272,7 +272,7 @@ class TestEnrichResponse:
         invalidate_rules_cache()
         with patch("obsidian_mcp.middleware.get_vault_path", return_value=rules_file):
             result = enrich_response(
-                tool_name="quick_capture",
+                tool_name="inbox.capture",
                 result="Captura guardada",
                 title="Idea rapida",
                 frontmatter={"type": "inbox", "status": "captura", "tags": []},
@@ -284,7 +284,7 @@ class TestEnrichResponse:
         invalidate_rules_cache()
         with patch("obsidian_mcp.middleware.get_vault_path", return_value=rules_file):
             result = enrich_response(
-                tool_name="append_to_note",
+                tool_name="notes.append",
                 result="Contenido agregado",
                 content="Texto normal sin problemas",
             )

--- a/tests/test_profile_prompts_resources.py
+++ b/tests/test_profile_prompts_resources.py
@@ -93,6 +93,15 @@ def test_profile_resources_register_and_read_declared_standard(tmp_path, monkeyp
     assert "obsidian://profile" in resources
     assert "obsidian://skills/list" in resources
     assert "obsidian://skills/catalog" in resources
+    assert "obsidian://docs/agent-quickstart" in resources
+
+    quickstart = asyncio.run(mcp.read_resource("obsidian://docs/agent-quickstart"))
+    quickstart_text = str(quickstart)
+    # Boot sequence and decision-table sanity check
+    assert "read_vault_context" in quickstart_text
+    assert "get_global_rules" in quickstart_text
+    assert "find_broken_wikilinks" in quickstart_text
+    assert "paths=" in quickstart_text  # the read_notes trap warning
     assert "obsidian://skills/{name}" in templates
     assert "obsidian://standards/{name}" in templates
     assert "obsidian://local_docs/{name}" in templates

--- a/tests/test_profile_prompts_resources.py
+++ b/tests/test_profile_prompts_resources.py
@@ -42,8 +42,8 @@ def test_core_prompts_register_without_vault_profile(tmp_path, monkeypatch):
     assert "update_media_item" not in prompt_names
     assert "prompt_actualizar_media" not in prompt_names
     assert all(not name.startswith("prompt_") for name in prompt_names)
-    assert "ask_vault" not in tool_names
-    assert "rag_health" not in tool_names
+    assert "rag.ask" not in tool_names
+    assert "rag.health" not in tool_names
     assert "preguntar_al_conocimiento" not in tool_names
 
 
@@ -98,16 +98,16 @@ def test_profile_resources_register_and_read_declared_standard(tmp_path, monkeyp
     quickstart = asyncio.run(mcp.read_resource("obsidian://docs/agent-quickstart"))
     quickstart_text = str(quickstart)
     # Boot sequence and decision-table sanity check
-    assert "read_vault_context" in quickstart_text
-    assert "get_global_rules" in quickstart_text
-    assert "find_broken_wikilinks" in quickstart_text
-    assert "paths=" in quickstart_text  # the read_notes trap warning
+    assert "vault.context" in quickstart_text
+    assert "rules.get" in quickstart_text
+    assert "links.find_broken" in quickstart_text
+    assert "paths=" in quickstart_text  # the notes.read_many trap warning
     assert "obsidian://skills/{name}" in templates
     assert "obsidian://standards/{name}" in templates
     assert "obsidian://local_docs/{name}" in templates
     assert "Media Standard" in str(standard)
     assert "Local Index" in str(local_doc)
-    assert "health_check" in str(capabilities)
+    assert "vault.health" in str(capabilities)
     assert "when_to_use" in str(catalog)
 
 
@@ -118,10 +118,10 @@ def test_diagnostic_tools_are_registered_and_report_profile(tmp_path, monkeypatc
 
     mcp = create_server()
     tool_names = {tool.name for tool in asyncio.run(mcp.list_tools())}
-    health_tool = asyncio.run(mcp.get_tool("health_check"))
-    diagnosis_tool = asyncio.run(mcp.get_tool("diagnose_vault_setup"))
-    roots_tool = asyncio.run(mcp.get_tool("list_client_roots"))
-    route_tool = asyncio.run(mcp.get_tool("route_task"))
+    health_tool = asyncio.run(mcp.get_tool("vault.health"))
+    diagnosis_tool = asyncio.run(mcp.get_tool("vault.diagnose"))
+    roots_tool = asyncio.run(mcp.get_tool("client.roots"))
+    route_tool = asyncio.run(mcp.get_tool("route.task"))
     health = asyncio.run(health_tool.run({}))
     diagnosis = asyncio.run(diagnosis_tool.run({}))
     route = asyncio.run(
@@ -131,11 +131,11 @@ def test_diagnostic_tools_are_registered_and_report_profile(tmp_path, monkeypatc
         route_tool.run({"request": "Busca una película sobre una modelo y asesinatos"})
     )
 
-    assert "health_check" in tool_names
-    assert "diagnose_vault_setup" in tool_names
-    assert "list_client_roots" in tool_names
+    assert "vault.health" in tool_names
+    assert "vault.diagnose" in tool_names
+    assert "client.roots" in tool_names
     assert roots_tool.annotations.readOnlyHint is True
-    assert "route_task" in tool_names
+    assert "route.task" in tool_names
     assert "profile_configured" in str(health)
     assert "integration:obsidianrag:path" in str(health)
     assert "No setup issues detected" in str(diagnosis)
@@ -158,18 +158,18 @@ def test_obsidianrag_pack_registers_resources_and_tools(tmp_path, monkeypatch):
     )
     capabilities = asyncio.run(mcp.read_resource("obsidian://capabilities"))
 
-    assert "ask_vault" in tool_names
-    assert "rag_health" in tool_names
-    assert "rebuild_rag_index" in tool_names
-    assert "rag_setup_status" in tool_names
+    assert "rag.ask" in tool_names
+    assert "rag.health" in tool_names
+    assert "rag.rebuild_index" in tool_names
+    assert "rag.setup_status" in tool_names
     assert "obsidian://integrations/obsidianrag/setup" in resources
     assert "obsidian://integrations/obsidianrag/config" in resources
     assert "ObsidianRAG" in str(setup)
     assert "Ollama" in str(setup)
-    assert "list_client_roots" in str(setup)
+    assert "client.roots" in str(setup)
     assert "obsidianrag serve" in str(setup)
     assert "api_url" in str(config)
-    assert "ask_vault" in str(capabilities)
+    assert "rag.ask" in str(capabilities)
 
 
 def test_obsidianrag_rejects_non_loopback_api_url(tmp_path, monkeypatch):

--- a/tests/test_tool_registry_contract.py
+++ b/tests/test_tool_registry_contract.py
@@ -17,11 +17,11 @@ def test_tool_sets_gate_optional_tools(tmp_path, monkeypatch):
     mcp = create_server()
     tool_names = {tool.name for tool in asyncio.run(mcp.list_tools())}
 
-    assert "read_note" in tool_names
-    assert "list_client_roots" in tool_names
-    assert "create_note" not in tool_names
-    assert "get_vault_stats" not in tool_names
-    assert "ask_vault" not in tool_names
+    assert "notes.read" in tool_names
+    assert "client.roots" in tool_names
+    assert "notes.create" not in tool_names
+    assert "vault.stats" not in tool_names
+    assert "rag.ask" not in tool_names
 
 
 def test_tool_set_env_enables_optional_tools(tmp_path, monkeypatch):
@@ -34,10 +34,10 @@ def test_tool_set_env_enables_optional_tools(tmp_path, monkeypatch):
     mcp = create_server()
     tool_names = {tool.name for tool in asyncio.run(mcp.list_tools())}
 
-    assert "create_note" in tool_names
-    assert "preview_replace_in_notes" in tool_names
-    assert "get_vault_stats" in tool_names
-    assert "ask_vault" not in tool_names
+    assert "notes.create" in tool_names
+    assert "notes.preview_replace" in tool_names
+    assert "vault.stats" in tool_names
+    assert "rag.ask" not in tool_names
 
 
 def test_public_tool_names_are_english(tmp_path, monkeypatch):
@@ -79,8 +79,8 @@ def test_write_tool_annotations_are_exposed(tmp_path, monkeypatch):
     invalidate_skills_cache()
 
     mcp = create_server()
-    create_note = asyncio.run(mcp.get_tool("create_note"))
-    delete_note = asyncio.run(mcp.get_tool("delete_note"))
+    create_note = asyncio.run(mcp.get_tool("notes.create"))
+    delete_note = asyncio.run(mcp.get_tool("notes.delete"))
 
     assert create_note.annotations.readOnlyHint is False
     assert create_note.annotations.idempotentHint is False

--- a/tests/test_wikilink_tools.py
+++ b/tests/test_wikilink_tools.py
@@ -1,0 +1,93 @@
+"""End-to-end tests for the wikilink-hygiene tools (Issues #6, #7, #11)."""
+
+import pytest
+
+from obsidian_mcp.config import reset_settings
+from obsidian_mcp.tools.analysis_logic import find_broken_wikilinks
+from obsidian_mcp.tools.navigation_logic import move_note
+
+
+@pytest.fixture
+def vault(tmp_path, monkeypatch):
+    v = tmp_path / "vault"
+    v.mkdir()
+    (v / "A.md").write_text(
+        "# A\n[[B]] and [[C|cee]] and [[Missing]]\n",
+        encoding="utf-8",
+    )
+    (v / "B.md").write_text("# B\n[[A]] [[Missing#sec]]\n", encoding="utf-8")
+    (v / "C.md").write_text("# C\nbody\n", encoding="utf-8")
+    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(v))
+    reset_settings()
+    return v
+
+
+class TestFindBrokenWikilinks:
+    """Issue #6."""
+
+    def test_reports_broken_links_with_source_and_line(self, vault):
+        result = find_broken_wikilinks()
+        assert result.success
+        text = result.data
+        assert "Missing" in text
+        assert "A.md" in text
+        assert "B.md" in text
+        # Format: "  L<n>: [[Missing]]" -- line number must be present
+        assert "L2" in text
+
+    def test_no_broken_links_returns_ok(self, tmp_path, monkeypatch):
+        v = tmp_path / "clean"
+        v.mkdir()
+        (v / "x.md").write_text("# x\n[[y]]\n", encoding="utf-8")
+        (v / "y.md").write_text("# y\n[[x]]\n", encoding="utf-8")
+        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(v))
+        reset_settings()
+        result = find_broken_wikilinks()
+        assert result.success
+        assert "No se encontraron" in result.data
+
+    def test_suggestions_for_typo(self, vault):
+        # Add a near-stem so the fuzzy matcher has something to suggest.
+        (vault / "Missing Note.md").write_text("# m\n", encoding="utf-8")
+        result = find_broken_wikilinks()
+        assert "Missing Note" in result.data
+
+    def test_limit_caps_results(self, vault):
+        result = find_broken_wikilinks(limit=1)
+        assert result.success
+        assert "mas" in result.data or "más" in result.data or "1 (" in result.data
+
+
+class TestMoveNoteUpdateLinks:
+    """Issues #7 and #11."""
+
+    def test_update_links_rewrites_references(self, vault):
+        """Moving B.md to Beta.md with update_links=True rewrites [[B]] -> [[Beta]]."""
+        result = move_note("B.md", "Beta.md", update_links=True)
+        assert result.success
+        a_content = (vault / "A.md").read_text(encoding="utf-8")
+        assert "[[Beta]]" in a_content
+        assert "[[B]]" not in a_content
+        assert "Links updated:" in result.data
+
+    def test_warns_when_links_left_stale(self, vault):
+        """Issue #11: default move surfaces unresolved references count."""
+        result = move_note("B.md", "Beta.md", update_links=False)
+        assert result.success
+        # A.md references [[B]]; the move leaves it stale.
+        assert "old stem 'B'" in result.data
+        assert "Re-run with update_links=True" in result.data
+
+    def test_preserves_alias_when_renaming(self, vault):
+        result = move_note("C.md", "Charlie.md", update_links=True)
+        assert result.success
+        a_content = (vault / "A.md").read_text(encoding="utf-8")
+        assert "[[Charlie|cee]]" in a_content
+
+    def test_no_warning_when_no_references(self, vault):
+        # D.md has no incoming references.
+        (vault / "D.md").write_text("# D\nstandalone\n", encoding="utf-8")
+        result = move_note("D.md", "DD.md", update_links=False)
+        assert result.success
+        assert "old stem" not in result.data
+        assert "Re-run" not in result.data

--- a/tests/test_wikilinks.py
+++ b/tests/test_wikilinks.py
@@ -1,0 +1,165 @@
+"""Tests for the shared wikilink scanning/rewriting engine."""
+
+import pytest
+
+from obsidian_mcp.utils.wikilinks import (
+    parse_wikilink,
+    rewrite_wikilinks_in_content,
+    rewrite_wikilinks_in_vault,
+    scan_broken_wikilinks,
+)
+
+
+@pytest.fixture
+def vault(tmp_path):
+    """Vault with cross-referenced notes for wikilink tests."""
+    v = tmp_path / "vault"
+    v.mkdir()
+    (v / "A.md").write_text(
+        "# A\nlink to [[B]] and [[C|alias]] and [[B#Section]]\n",
+        encoding="utf-8",
+    )
+    (v / "B.md").write_text(
+        "# B\nlink to [[A]] and ![[image.png]] and [[Missing Target]]\n",
+        encoding="utf-8",
+    )
+    (v / "folder").mkdir()
+    (v / "folder" / "C.md").write_text("# C\nbody\n", encoding="utf-8")
+    return v
+
+
+class TestParseWikilink:
+    def test_bare_target(self):
+        assert parse_wikilink("Note") == ("Note", None, None)
+
+    def test_alias(self):
+        assert parse_wikilink("Note|alias") == ("Note", None, "alias")
+
+    def test_section(self):
+        assert parse_wikilink("Note#Section") == ("Note", "Section", None)
+
+    def test_section_and_alias(self):
+        assert parse_wikilink("Note#Section|alias") == (
+            "Note",
+            "Section",
+            "alias",
+        )
+
+    def test_whitespace_is_stripped(self):
+        assert parse_wikilink("  Note  |  alias  ") == ("Note", None, "alias")
+
+
+class TestScanBrokenWikilinks:
+    def test_finds_missing_target(self, vault):
+        broken = scan_broken_wikilinks(vault)
+        targets = [b.occurrence.target for b in broken]
+        assert "Missing Target" in targets
+        assert "B" not in targets  # exists
+        assert "C" not in targets  # exists in folder/
+
+    def test_excludes_image_embeds(self, vault):
+        broken = scan_broken_wikilinks(vault)
+        assert all(b.occurrence.target != "image.png" for b in broken)
+
+    def test_section_anchors_resolve_to_note(self, vault):
+        """[[B#Section]] resolves if B.md exists, even if no Section heading."""
+        broken = scan_broken_wikilinks(vault)
+        assert all(b.occurrence.target != "B" for b in broken)
+
+    def test_records_source_file_and_line(self, vault):
+        broken = scan_broken_wikilinks(vault)
+        miss = next(b for b in broken if b.occurrence.target == "Missing Target")
+        assert miss.occurrence.source.name == "B.md"
+        assert miss.occurrence.line_no == 2
+
+    def test_suggests_close_matches(self, vault):
+        # Add a near-miss target name to provoke a suggestion.
+        (vault / "Missing Targets.md").write_text("# x\n", encoding="utf-8")
+        broken = scan_broken_wikilinks(vault)
+        miss = next(b for b in broken if b.occurrence.target == "Missing Target")
+        assert "Missing Targets" in miss.suggestions
+
+
+class TestRewriteWikilinksInContent:
+    def test_simple_replace(self):
+        new, count = rewrite_wikilinks_in_content(
+            "see [[Old Name]] today",
+            old_target="Old Name",
+            new_target="New Name",
+        )
+        assert count == 1
+        assert new == "see [[New Name]] today"
+
+    def test_preserves_alias(self):
+        new, _ = rewrite_wikilinks_in_content(
+            "[[Old|click here]]", old_target="Old", new_target="New"
+        )
+        assert new == "[[New|click here]]"
+
+    def test_preserves_section(self):
+        new, _ = rewrite_wikilinks_in_content(
+            "[[Old#Intro]]", old_target="Old", new_target="New"
+        )
+        assert new == "[[New#Intro]]"
+
+    def test_preserves_section_and_alias(self):
+        new, _ = rewrite_wikilinks_in_content(
+            "[[Old#Intro|see here]]", old_target="Old", new_target="New"
+        )
+        assert new == "[[New#Intro|see here]]"
+
+    def test_ignores_unrelated_links(self):
+        new, count = rewrite_wikilinks_in_content(
+            "[[Other]] and [[Old]] and [[Third]]",
+            old_target="Old",
+            new_target="Renamed",
+        )
+        assert count == 1
+        assert new == "[[Other]] and [[Renamed]] and [[Third]]"
+
+    def test_ignores_image_embeds(self):
+        new, count = rewrite_wikilinks_in_content(
+            "![[Old.png]] and [[Old]]",
+            old_target="Old",
+            new_target="New",
+        )
+        # Only the non-embed link is rewritten.
+        assert count == 1
+        assert "![[Old.png]]" in new
+        assert "[[New]]" in new
+
+    def test_old_equals_new_is_noop(self):
+        new, count = rewrite_wikilinks_in_content(
+            "[[Same]]", old_target="Same", new_target="Same"
+        )
+        assert count == 0
+        assert new == "[[Same]]"
+
+
+class TestRewriteWikilinksInVault:
+    def test_updates_all_references(self, vault):
+        # B is referenced from A
+        total, touched = rewrite_wikilinks_in_vault(
+            vault, old_target="B", new_target="Beta"
+        )
+        assert total >= 1
+        assert any(p.name == "A.md" for p in touched)
+        assert "[[Beta]]" in (vault / "A.md").read_text(encoding="utf-8")
+        assert "[[Beta#Section]]" in (vault / "A.md").read_text(encoding="utf-8")
+
+    def test_dry_run_does_not_write(self, vault):
+        original_a = (vault / "A.md").read_text(encoding="utf-8")
+        total, touched = rewrite_wikilinks_in_vault(
+            vault, old_target="B", new_target="Beta", dry_run=True
+        )
+        assert total >= 1
+        assert touched
+        # File contents unchanged.
+        assert (vault / "A.md").read_text(encoding="utf-8") == original_a
+
+    def test_no_match_returns_zero(self, vault):
+        total, touched = rewrite_wikilinks_in_vault(
+            vault, old_target="NonExistent", new_target="X"
+        )
+        assert total == 0
+        assert not touched

--- a/uv.lock
+++ b/uv.lock
@@ -1557,11 +1557,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes every actionable item in `docs/agent-feedback/2026-05-17-recommendations.md` (15/15 issues from the heavy-audit session that exercised the MCP at vault scale).

Split into 5 logical commits for layered review:

1. **Tanda 1 — quick wins** (`19adbdc`): REGLAS dumped only on violations (#3), `notes.validate` tool (#10), ES-centralized confirmation messages (#13), docs for `read_notes(paths=)` / tag coercion / naming (#12, #14, #15 docs).
2. **Tanda 2 — core bug fixes** (`866dea2`): specific cancellation reasons (#1), embedded frontmatter merge (#2), fuzzy suggestions on `patch_note` miss (#8), `list_notes` pagination + glob filter (#5).
3. **Tanda 3 — wikilink hygiene + onboarding** (`afa31b7`): shared `wikilinks` module, `links.find_broken` (#6), `notes.rename` + `notes.move(update_links=True)` with stale-ref reporting (#7, #11), `obsidian://docs/agent-quickstart` MCP resource (#4).
4. **Tanda 4 — vault-wide lint sweep** (`bdbca98`): `vault.lint` with regex-based auto-fix engine (#9). Replaces the ~60 manual `patch_note` calls the original session burned stripping emojis.
5. **Tanda 5 — namespace.method rename** (`a2c3619`, **breaking**): 77 public tools renamed from verb-first / underscore-namespaced to a single `namespace.verb` convention (#15). Includes `idna 3.11 → 3.15` to clear pip-audit.

## Breaking changes

Tanda 5 is a hard break of the public tool-name contract. Every MCP client must be updated. Internal Python identifiers are unchanged. See the commit body for the full mapping; representative examples:

- `create_note` → `notes.create`
- `patch_note` → `notes.patch`
- `read_notes` → `notes.read_many`
- `read_vault_context` → `vault.context`
- `find_broken_wikilinks` → `links.find_broken`
- `quick_capture` → `inbox.capture`
- `ask_vault` → `rag.ask`
- `canvas_add_card` → `canvas.add_card`
- `kanvas_propose_task` → `kanvas.propose_task`

## Test plan

- [x] `uv run pytest` — 340 passed, 4 skipped (semantic backend), 1 deselected (pre-existing `.env` test unrelated to this PR)
- [x] Pre-commit hooks on every tanda (ruff, ruff-format, pyright, pylint, bandit, pip-audit)
- [x] Manual: connect a real Claude Code session to a vault and exercise `notes.create`, `notes.patch`, `vault.lint`, `links.find_broken`, `notes.rename(update_links=True)`.
- [x] Manual: verify `delete_note`/`replace_note` cancellation messages with a host that doesn't surface `elicit()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)