### PR TITLE
fix: address AFP dogfooding regressions

### DIFF
--- a/obsidian_mcp/models/tool_inputs.py
+++ b/obsidian_mcp/models/tool_inputs.py
@@ -24,7 +24,10 @@ class CreateNoteInput(BaseModel):
 class AppendToNoteInput(BaseModel):
     note_path: str = Field(description="Note path or filename.")
     content: str = Field(description="Content to insert.")
-    position: str = Field(default="end", description="'end', 'start', or 'section'.")
+    position: str = Field(
+        default="end",
+        description="'end', 'append', 'start', or 'section'. 'append' is an alias for 'end'.",
+    )
     section: str = Field(default="", description="Section heading for section inserts.")
     create_section: bool = Field(
         default=True,
@@ -34,6 +37,10 @@ class AppendToNoteInput(BaseModel):
 
 class DeleteNoteInput(BaseModel):
     note_path: str = Field(description="Note path or filename to delete.")
+    confirm: bool = Field(
+        default=False,
+        description="Must be true to acknowledge permanent deletion.",
+    )
 
 
 class EditOperation(BaseModel):
@@ -80,7 +87,9 @@ class FrontmatterInput(BaseModel):
 
 class UpdateFrontmatterInput(BaseModel):
     note_path: str = Field(description="Note path or filename.")
-    frontmatter_updates: str = Field(description="JSON object with metadata updates.")
+    frontmatter_updates: str = Field(
+        description='JSON object encoded as a string, e.g. {"status": "en_proceso"}.'
+    )
     merge: bool = Field(default=True, description="Merge with existing frontmatter.")
 
 

--- a/obsidian_mcp/tools/creation.py
+++ b/obsidian_mcp/tools/creation.py
@@ -127,14 +127,16 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
                 result = append_to_section(
                     note_path, section, content, create_section
                 ).to_display(success_prefix="OK")
-            elif normalized_position in {"end", "start"}:
+            elif normalized_position in {"end", "start", "append"}:
+                if normalized_position == "append":
+                    normalized_position = "end"
                 result = append_to_note_logic(
                     note_path,
                     content,
                     al_final=normalized_position == "end",
                 ).to_display(success_prefix="OK")
             else:
-                return "Error: position must be 'end', 'start', or 'section'."
+                return "Error: position must be 'end', 'append', 'start', or 'section'."
 
             return enrich_response(
                 tool_name="notes.append",
@@ -145,8 +147,11 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
             return f"Error appending to note: {e}"
 
     @register_tool(mcp, "notes.delete")
-    async def delete_note(note_path: str, ctx: Context) -> str:
+    async def delete_note(note_path: str, ctx: Context, confirm: bool = False) -> str:
         """Delete a note after explicit client confirmation."""
+        if not confirm:
+            return "Error: confirm=True is required to delete a note."
+
         try:
             result = await ctx.elicit(
                 f"Permanently delete '{note_path}'? This cannot be undone.",

--- a/obsidian_mcp/tools/creation_logic.py
+++ b/obsidian_mcp/tools/creation_logic.py
@@ -998,7 +998,7 @@ def search_and_replace_global(
             resultado += f"- `{arch['ruta_rel']}` ({arch['ocurrencias']} ocurrencias)\n"
         if len(archivos_afectados) > 20:
             resultado += f"- ... y {len(archivos_afectados) - 20} archivos más\n"
-        resultado += "\n⚠️ Ejecuta con `solo_preview=False` para aplicar los cambios."
+        resultado += "\n⚠️ Usa `notes.apply_replace` para aplicar los cambios."
         return Result.ok(resultado)
 
     # Modo ejecución
@@ -1234,6 +1234,11 @@ def update_frontmatter_logic(
         updates_dict = json.loads(frontmatter_updates)
     except json.JSONDecodeError:
         return Result.fail("frontmatter_updates debe ser un JSON string válido.")
+
+    if not isinstance(updates_dict, dict):
+        return Result.fail(
+            "frontmatter_updates debe ser un objeto JSON codificado como string."
+        )
 
     try:
         with open(nota_path, "r", encoding="utf-8") as f:

--- a/obsidian_mcp/tools/graph_logic.py
+++ b/obsidian_mcp/tools/graph_logic.py
@@ -10,7 +10,12 @@ from typing import Dict, List
 
 from ..config import get_vault_path
 from ..result import Result
-from ..utils import extract_internal_links, extract_tags_from_content, get_logger
+from ..utils import (
+    extract_internal_links,
+    extract_tags_from_content,
+    find_note_by_name,
+    get_logger,
+)
 
 logger = get_logger(__name__)
 
@@ -197,17 +202,12 @@ def get_local_graph(nombre_nota: str, profundidad: int = 1) -> Result[str]:
         if not vault_path:
             return Result.fail("La ruta del vault no está configurada.")
 
-        nombre_limpio = nombre_nota.replace(".md", "")
-
-        # Find note
-        nota_path = None
-        for archivo in vault_path.rglob("*.md"):
-            if archivo.stem == nombre_limpio:
-                nota_path = archivo
-                break
+        nota_path = find_note_by_name(nombre_nota)
 
         if not nota_path:
             return Result.fail(f"No se encontró la nota '{nombre_nota}'")
+
+        nombre_limpio = nota_path.stem
 
         # Get outgoing links
         with open(nota_path, "r", encoding="utf-8") as f:

--- a/tests/test_afp_dogfood_regressions.py
+++ b/tests/test_afp_dogfood_regressions.py
@@ -1,0 +1,103 @@
+"""Regression tests from AFP dogfooding reports."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from obsidian_mcp.config import reset_settings
+from obsidian_mcp.server import create_server
+from obsidian_mcp.tools.creation_logic import (
+    search_and_replace_global,
+    update_frontmatter_logic,
+)
+from obsidian_mcp.tools.graph_logic import get_local_graph
+from obsidian_mcp.utils import invalidate_note_cache
+from obsidian_mcp.vault_config import invalidate_vault_config_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_state_after_test():
+    yield
+    reset_settings()
+    invalidate_note_cache()
+    invalidate_vault_config_cache()
+
+
+def _set_vault(monkeypatch, tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+    monkeypatch.setenv("OBSIDIAN_MCP_TOOL_SETS", "notes_write,vault_analysis")
+    reset_settings()
+    invalidate_note_cache()
+    return vault
+
+
+def test_preview_replace_points_agents_to_apply_replace(tmp_path, monkeypatch):
+    vault = _set_vault(monkeypatch, tmp_path)
+    note = vault / "note.md"
+    note.write_text("before target after", encoding="utf-8")
+
+    result = search_and_replace_global("target", "replacement", solo_preview=True)
+
+    assert result.success
+    assert "notes.apply_replace" in result.data
+    assert "solo_preview=False" not in result.data
+
+
+def test_update_frontmatter_rejects_json_that_is_not_an_object(tmp_path, monkeypatch):
+    vault = _set_vault(monkeypatch, tmp_path)
+    note = vault / "note.md"
+    note.write_text("---\ntitle: Test\n---\n\nBody\n", encoding="utf-8")
+
+    result = update_frontmatter_logic("note.md", '["not", "an", "object"]')
+
+    assert not result.success
+    assert "objeto JSON" in result.error
+    assert note.read_text(encoding="utf-8") == "---\ntitle: Test\n---\n\nBody\n"
+
+
+def test_notes_append_accepts_append_as_end_alias(tmp_path, monkeypatch):
+    vault = _set_vault(monkeypatch, tmp_path)
+    note = vault / "note.md"
+    note.write_text("# Note\n\nOriginal\n", encoding="utf-8")
+    mcp = create_server()
+    append_tool = asyncio.run(mcp.get_tool("notes.append"))
+
+    result = append_tool.fn("note.md", "Added", position="append")
+
+    assert result.startswith("OK")
+    content = note.read_text(encoding="utf-8")
+    assert content.index("Added") > content.index("Original")
+
+
+def test_local_graph_accepts_vault_relative_paths(tmp_path, monkeypatch):
+    vault = _set_vault(monkeypatch, tmp_path)
+    folder = vault / "Projects" / "AFP"
+    folder.mkdir(parents=True)
+    note = folder / "Agent Feedback Protocol.md"
+    note.write_text("# Agent Feedback Protocol\n\n[[Neighbor]]\n", encoding="utf-8")
+    (vault / "Neighbor.md").write_text(
+        "[[Agent Feedback Protocol]]\n", encoding="utf-8"
+    )
+
+    result = get_local_graph("Projects/AFP/Agent Feedback Protocol.md")
+
+    assert result.success
+    assert "Neighbor" in result.data
+
+
+def test_notes_delete_requires_explicit_confirm_argument(tmp_path, monkeypatch):
+    vault = _set_vault(monkeypatch, tmp_path)
+    note = vault / "scratch.md"
+    note.write_text("temporary", encoding="utf-8")
+    mcp = create_server()
+    delete_tool = asyncio.run(mcp.get_tool("notes.delete"))
+    ctx = SimpleNamespace(elicit=lambda *args, **kwargs: None)
+
+    assert delete_tool.parameters["properties"]["confirm"]["default"] is False
+    result = asyncio.run(delete_tool.fn("scratch.md", ctx, confirm=False))
+
+    assert "confirm" in result.lower()
+    assert note.exists()


### PR DESCRIPTION
## Summary

- Fixes AFP dogfooding regressions found while exercising Obsidian MCP tools.
- Points `notes.preview_replace` users to `notes.apply_replace` instead of the obsolete `solo_preview=False` instruction.
- Tightens note write contracts: `frontmatter_updates` must decode to a JSON object, `position="append"` aliases to end append, and `notes.delete` now requires `confirm=True`.
- Reuses the standard note resolver in `links.local_graph` so vault-relative paths work consistently.

## Validation

- `env UV_CACHE_DIR=/tmp/uvcache uv run pytest -q`
- `env UV_CACHE_DIR=/tmp/uvcache uv run ruff check .`
- pre-commit hooks on commit: ruff, ruff-format, pyright, pylint, bandit, pip-audit

Fixes #40
Fixes #41
Fixes #42
Fixes #43
