### PR TITLE
fix: close AFP dogfooding reports

### DIFF
--- a/obsidian_mcp/tools/analysis_logic.py
+++ b/obsidian_mcp/tools/analysis_logic.py
@@ -268,7 +268,12 @@ def sync_tag_registry(  # pylint: disable=too-many-locals,too-many-branches
         vault_path / "04_Recursos" / "Obsidian" / "Registro de Tags del Vault.md"
     )
     if not registry_path.exists():
-        return Result.fail("No se encontró el registro oficial de tags.")
+        return Result.fail(
+            "No se encontró el registro oficial de tags. "
+            "Crea el archivo en "
+            "'04_Recursos/Obsidian/Registro de Tags del Vault.md' "
+            "o usa tags.list/tags.analyze sin sincronización hasta inicializarlo."
+        )
 
     # 1. Get tags from reality
     conteo_real: dict[str, int] = {}

--- a/obsidian_mcp/tools/creation.py
+++ b/obsidian_mcp/tools/creation.py
@@ -1,6 +1,7 @@
 """MCP note creation and editing tools."""
 
 import json
+from time import perf_counter
 
 from fastmcp import Context, FastMCP
 
@@ -45,6 +46,11 @@ def _cancellation_reason(action: str) -> str:
     if action == "cancel":
         return ERRORS.OPERATION_DISMISSED
     return ERRORS.OPERATION_DECLINED
+
+
+def _with_duration(result: str, started_at: float) -> str:
+    """Append elapsed time context for synchronous write operations."""
+    return f"{result}\n- Duración: {perf_counter() - started_at:.2f}s"
 
 
 def _extract_fm(content: str) -> dict:
@@ -163,9 +169,11 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
             return ERRORS.OPERATION_CANCELLED_NO_CONFIRM
 
         try:
-            return delete_note_logic(note_path, confirmar=True).to_display(
+            started_at = perf_counter()
+            result = delete_note_logic(note_path, confirmar=True).to_display(
                 success_prefix="OK"
             )
+            return _with_duration(result, started_at)
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error deleting note: {e}"
 
@@ -219,16 +227,16 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
             return ERRORS.OPERATION_CANCELLED_NO_CONFIRM
 
         try:
+            started_at = perf_counter()
             edit_result = edit_note(
                 note_path, [{"old": "", "new": content}]
             ).to_display(success_prefix="OK")
             if "REGLAS_GLOBALES" in note_path:
                 invalidate_rules_cache()
-            return enrich_response(
-                tool_name="notes.replace",
-                result=edit_result,
-                content=content,
+            result = enrich_response(
+                tool_name="notes.replace", result=edit_result, content=content
             )
+            return _with_duration(result, started_at)
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error replacing note: {e}"
 
@@ -272,13 +280,15 @@ def register_creation_tools(mcp: FastMCP) -> None:  # pylint: disable=too-many-s
             return ERRORS.OPERATION_CANCELLED_NO_CONFIRM
 
         try:
-            return search_and_replace_global(
+            started_at = perf_counter()
+            result = search_and_replace_global(
                 search,
                 replacement,
                 folder,
                 solo_preview=False,
                 limite=limit,
             ).to_display()
+            return _with_duration(result, started_at)
         except Exception as e:  # pylint: disable=broad-exception-caught
             return f"Error applying replacement: {e}"
 

--- a/obsidian_mcp/tools/creation_logic.py
+++ b/obsidian_mcp/tools/creation_logic.py
@@ -740,6 +740,7 @@ def create_note(
     # Preparar contenido final
     contenido_final = ""
     ahora = datetime.now().strftime("%Y-%m-%d")
+    tags_list = [t.strip() for t in etiquetas.split(",") if t.strip()]
 
     # Si se usa plantilla
     if plantilla:
@@ -801,12 +802,26 @@ def create_note(
             # Procesar todas las fechas con formatos
             plantilla_content = _process_date_placeholders(plantilla_content)
 
-            contenido_final = plantilla_content
+            template_metadata, template_body = _extract_frontmatter_from_content(
+                plantilla_content
+            )
+            extra_metadata, contenido_limpio = _extract_frontmatter_from_content(
+                contenido
+            )
+            combined_metadata = dict(template_metadata)
+            combined_metadata.update(extra_metadata)
+
+            contenido_final = _build_frontmatter(
+                titulo=titulo,
+                ahora=ahora,
+                tags_list=tags_list,
+                agente_creador=agente_creador,
+                extra_metadata=combined_metadata if combined_metadata else None,
+            )
+            contenido_final += template_body
+
             # Si hay contenido adicional, añadirlo al final
             if contenido:
-                # Extraer frontmatter del contenido si existe
-                # para evitar duplicación con la plantilla
-                _, contenido_limpio = _extract_frontmatter_from_content(contenido)
                 if contenido_final.endswith("\n\n"):
                     contenido_final += contenido_limpio
                 else:
@@ -815,8 +830,6 @@ def create_note(
             return Result.fail(f"No se encontró la plantilla '{plantilla}'")
     else:
         # Sin plantilla: detectar si el contenido ya tiene frontmatter
-        tags_list = [t.strip() for t in etiquetas.split(",") if t.strip()]
-
         # Extraer frontmatter del contenido si existe
         extra_metadata, contenido_limpio = _extract_frontmatter_from_content(contenido)
 
@@ -1074,10 +1087,21 @@ def quick_capture(texto: str, etiquetas: str = "") -> Result[str]:
         if idea_template.exists():
             plantilla = "Idea.md"
 
-    # 4. Create the note
+    # 4. Create the note with inbox semantics preserved in frontmatter.
+    ahora_fecha = datetime.now().strftime("%Y-%m-%d")
+    contenido = (
+        "---\n"
+        "type: inbox\n"
+        "status: captura\n"
+        f"created: {ahora_fecha}\n"
+        f"updated: {ahora_fecha}\n"
+        "---\n\n"
+        f"{texto}"
+    )
+
     return create_note(
         titulo=titulo,
-        contenido=texto,
+        contenido=contenido,
         carpeta=inbox_folder,
         etiquetas=etiquetas,
         plantilla=plantilla,

--- a/tests/test_afp_dogfood_regressions.py
+++ b/tests/test_afp_dogfood_regressions.py
@@ -4,9 +4,11 @@ import asyncio
 from types import SimpleNamespace
 
 import pytest
+import yaml
 
 from obsidian_mcp.config import reset_settings
 from obsidian_mcp.server import create_server
+from obsidian_mcp.tools.analysis_logic import sync_tag_registry
 from obsidian_mcp.tools.creation_logic import (
     search_and_replace_global,
     update_frontmatter_logic,
@@ -28,10 +30,18 @@ def _set_vault(monkeypatch, tmp_path):
     vault = tmp_path / "vault"
     vault.mkdir()
     monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
-    monkeypatch.setenv("OBSIDIAN_MCP_TOOL_SETS", "notes_write,vault_analysis")
+    monkeypatch.setenv(
+        "OBSIDIAN_MCP_TOOL_SETS",
+        "notes_write,vault_analysis,secundo_selebro",
+    )
     reset_settings()
     invalidate_note_cache()
     return vault
+
+
+class _AcceptCtx:
+    async def elicit(self, *args, **kwargs):
+        return SimpleNamespace(action="accept")
 
 
 def test_preview_replace_points_agents_to_apply_replace(tmp_path, monkeypatch):
@@ -133,3 +143,102 @@ def test_notes_delete_requires_explicit_confirm_argument(tmp_path, monkeypatch):
 
     assert "confirm" in result.lower()
     assert note.exists()
+
+
+def test_inbox_capture_creates_valid_current_frontmatter(tmp_path, monkeypatch):
+    vault = _set_vault(monkeypatch, tmp_path)
+    inbox = vault / "00_Bandeja"
+    inbox.mkdir()
+    rules_dir = vault / ".agents"
+    rules_dir.mkdir()
+    (rules_dir / "REGLAS_GLOBALES.md").write_text(
+        "---\n"
+        "validations:\n"
+        "  - id: required_frontmatter\n"
+        "    applies_to: [create]\n"
+        "    scope: frontmatter\n"
+        "    required_fields: [type, status, tags]\n"
+        '    warning: "Frontmatter incompleto: faltan {missing_fields}"\n'
+        "---\n\n# Reglas\n",
+        encoding="utf-8",
+    )
+    mcp = create_server()
+    capture_tool = asyncio.run(mcp.get_tool("inbox.capture"))
+
+    result = capture_tool.fn("Idea rápida", tags="afp, mcp")
+
+    assert "[WARNINGS:" not in result
+    files = list(inbox.glob("*.md"))
+    assert len(files) == 1
+    frontmatter = yaml.safe_load(files[0].read_text(encoding="utf-8").split("---")[1])
+    assert frontmatter["type"] == "inbox"
+    assert frontmatter["status"] == "captura"
+    assert frontmatter["tags"] == ["afp", "mcp"]
+    assert str(frontmatter["created"]) == str(frontmatter["updated"])
+
+
+def test_inbox_capture_ignores_stale_idea_template_frontmatter(tmp_path, monkeypatch):
+    vault = _set_vault(monkeypatch, tmp_path)
+    inbox = vault / "00_Bandeja"
+    inbox.mkdir()
+    templates = vault / "Plantillas"
+    templates.mkdir()
+    (templates / "Idea.md").write_text(
+        "---\n"
+        "type: apunte\n"
+        "status: archivo\n"
+        "created: 2020-01-01\n"
+        "updated: 2020-01-01\n"
+        "---\n\n"
+        "# {{title}}\n\n"
+        "{{description}}\n",
+        encoding="utf-8",
+    )
+    mcp = create_server()
+    capture_tool = asyncio.run(mcp.get_tool("inbox.capture"))
+
+    capture_tool.fn("Idea con plantilla vieja", tags="afp")
+
+    files = list(inbox.glob("*.md"))
+    assert len(files) == 1
+    frontmatter = yaml.safe_load(files[0].read_text(encoding="utf-8").split("---")[1])
+    assert frontmatter["type"] == "inbox"
+    assert frontmatter["status"] == "captura"
+    assert frontmatter["created"] != "2020-01-01"
+    assert frontmatter["updated"] != "2020-01-01"
+
+
+def test_tag_registry_missing_error_includes_setup_path(tmp_path, monkeypatch):
+    _set_vault(monkeypatch, tmp_path)
+
+    result = sync_tag_registry()
+
+    assert not result.success
+    assert "04_Recursos/Obsidian/Registro de Tags del Vault.md" in result.error
+    assert "Crea" in result.error or "crear" in result.error.lower()
+
+
+def test_confirmed_write_tools_include_elapsed_time(tmp_path, monkeypatch):
+    vault = _set_vault(monkeypatch, tmp_path)
+    project = vault / "Project"
+    project.mkdir()
+    note = project / "scratch.md"
+    note.write_text("before target after", encoding="utf-8")
+    mcp = create_server()
+    apply_tool = asyncio.run(mcp.get_tool("notes.apply_replace"))
+    replace_tool = asyncio.run(mcp.get_tool("notes.replace"))
+    delete_tool = asyncio.run(mcp.get_tool("notes.delete"))
+
+    apply_result = asyncio.run(
+        apply_tool.fn("target", "replacement", _AcceptCtx(), folder="Project")
+    )
+    replace_result = asyncio.run(
+        replace_tool.fn("Project/scratch.md", "# Replaced\n", _AcceptCtx())
+    )
+    delete_result = asyncio.run(
+        delete_tool.fn("Project/scratch.md", _AcceptCtx(), confirm=True)
+    )
+
+    assert "Duración:" in apply_result
+    assert "Duración:" in replace_result
+    assert "Duración:" in delete_result


### PR DESCRIPTION
## Summary
- Fix `inbox.capture` so generated inbox notes keep current inbox frontmatter even when a stale `Idea.md` template exists.
- Improve `tags.sync_registry` missing-registry feedback with the expected path and fallback actions.
- Add elapsed-time feedback to confirmed write tools (`notes.delete`, `notes.replace`, `notes.apply_replace`).

## Validation
- `env UV_CACHE_DIR=/tmp/uvcache uv run pytest -q` -> 352 passed, 4 skipped.
- `env UV_CACHE_DIR=/tmp/uvcache uv run ruff check .` -> all checks passed.
- MCP stdio smoke tested the changed tools against a temp vault.

Fixes #44.
Fixes #45.
Fixes #46.
