### PR TITLE
fix: deduplicate YAML frontmatter keys before disk write

### DIFF
--- a/obsidian_mcp/tools/creation_logic.py
+++ b/obsidian_mcp/tools/creation_logic.py
@@ -39,6 +39,38 @@ def _json_serial(obj: Any) -> str:
 
 logger = get_logger(__name__)
 
+_FRONTMATTER_BLOCK_RE = re.compile(r"^(---\s*\n)(.*?\n)(---\s*\n)", re.DOTALL)
+
+
+def _normalize_frontmatter(content: str) -> str:
+    """Re-parse frontmatter through yaml round-trip to eliminate duplicate keys.
+
+    LLM clients sometimes generate YAML with repeated keys (e.g. two
+    ``created:`` lines).  ``yaml.safe_load`` silently keeps the last
+    value for each key; ``yaml.dump`` serialises the clean dict back.
+    """
+    match = _FRONTMATTER_BLOCK_RE.match(content)
+    if not match:
+        return content
+
+    raw_yaml = match.group(2)
+    try:
+        parsed = yaml.safe_load(raw_yaml)
+    except yaml.YAMLError:
+        return content
+
+    if not isinstance(parsed, dict):
+        return content
+
+    clean_yaml = yaml.dump(
+        parsed,
+        default_flow_style=False,
+        allow_unicode=True,
+        sort_keys=False,
+    )
+
+    return f"---\n{clean_yaml}---\n{content[match.end():]}"
+
 
 def _process_date_placeholders(content: str, date_obj: datetime | None = None) -> str:
     """
@@ -478,6 +510,7 @@ def edit_note(  # pylint: disable=too-many-locals,too-many-return-statements,too
         contenido_final = _update_frontmatter_date(
             contenido_final, user_set_updated=has_updated
         )
+        contenido_final = _normalize_frontmatter(contenido_final)
         with open(nota_path, "w", encoding="utf-8") as f:
             f.write(contenido_final)
         return Result.ok(f"Nota editada: {ruta_relativa} (reemplazo total)")
@@ -532,6 +565,7 @@ def edit_note(  # pylint: disable=too-many-locals,too-many-return-statements,too
 
     resultado = _process_date_placeholders(resultado)
     resultado = _update_frontmatter_date(resultado, user_set_updated=user_set_updated)
+    resultado = _normalize_frontmatter(resultado)
 
     with open(nota_path, "w", encoding="utf-8") as f:
         f.write(resultado)
@@ -852,6 +886,7 @@ def create_note(
 
     # Procesar cualquier placeholder de fecha restante en el contenido
     contenido_final = _process_date_placeholders(contenido_final)
+    contenido_final = _normalize_frontmatter(contenido_final)
 
     # Escribir archivo
     with open(nota_path, "w", encoding="utf-8") as f:

--- a/tests/test_normalize_frontmatter.py
+++ b/tests/test_normalize_frontmatter.py
@@ -1,0 +1,162 @@
+"""Tests for _normalize_frontmatter — deduplication of YAML keys.
+
+Regression: LLM clients sometimes emit YAML with repeated keys
+(e.g. two ``created:`` lines). The normalizer re-parses through
+yaml round-trip before every disk write to guarantee valid YAML.
+"""
+
+import pytest
+
+from obsidian_mcp.tools.creation_logic import (
+    _normalize_frontmatter,
+    create_note,
+    edit_note,
+)
+
+
+# --- Unit tests for _normalize_frontmatter ---
+
+
+class TestNormalizeFrontmatter:
+    def test_duplicate_created_is_deduplicated(self):
+        content = (
+            "---\n"
+            "title: Test\n"
+            "created: 2026-06-09\n"
+            "type: nota\n"
+            "created: '2026-06-09'\n"
+            "---\n\n"
+            "# Body\n"
+        )
+        result = _normalize_frontmatter(content)
+        assert result.count("created:") == 1
+        assert "# Body" in result
+
+    def test_last_value_wins(self):
+        content = (
+            "---\n"
+            "title: First\n"
+            "title: Second\n"
+            "---\n\n"
+            "body\n"
+        )
+        result = _normalize_frontmatter(content)
+        assert result.count("title:") == 1
+        assert "Second" in result
+
+    def test_no_frontmatter_unchanged(self):
+        content = "# Just a heading\n\nSome text.\n"
+        assert _normalize_frontmatter(content) == content
+
+    def test_valid_frontmatter_roundtrips_cleanly(self):
+        content = (
+            "---\n"
+            "title: Clean\n"
+            "created: 2026-01-01\n"
+            "tags:\n"
+            "- one\n"
+            "- two\n"
+            "---\n\n"
+            "body\n"
+        )
+        result = _normalize_frontmatter(content)
+        assert "title:" in result
+        assert "created:" in result
+        assert "body" in result
+
+    def test_body_preserved_after_normalization(self):
+        body = "## Section\n\nParagraph with `code` and **bold**.\n"
+        content = (
+            "---\n"
+            "title: X\n"
+            "title: Y\n"
+            "---\n\n"
+            + body
+        )
+        result = _normalize_frontmatter(content)
+        assert body in result
+
+    def test_invalid_yaml_left_untouched(self):
+        content = "---\n: bad yaml [\n---\n\nbody\n"
+        assert _normalize_frontmatter(content) == content
+
+
+# --- Integration tests with create_note ---
+
+
+@pytest.fixture
+def temp_vault(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    monkeypatch.setattr(
+        "obsidian_mcp.tools.creation_logic.get_vault_path",
+        lambda: vault,
+    )
+    monkeypatch.setattr(
+        "obsidian_mcp.tools.creation_logic.get_vault_config",
+        lambda *_args, **_kwargs: None,
+    )
+    return vault
+
+
+class TestCreateNoteDeduplicatesFrontmatter:
+    def test_embedded_duplicate_created_is_cleaned(self, temp_vault):
+        embedded = (
+            "---\n"
+            "title: Idea\n"
+            "created: 2026-06-09\n"
+            "type: investigacion\n"
+            "status: borrador\n"
+            "created: '2026-06-09'\n"
+            "tags: [idea]\n"
+            "---\n\n"
+            "## Body\n"
+        )
+        result = create_note(
+            titulo="Idea",
+            contenido=embedded,
+            carpeta="notes",
+        )
+        assert result.success
+        content = (temp_vault / "notes" / "Idea.md").read_text(encoding="utf-8")
+        assert content.count("created:") == 1
+
+
+class TestEditNoteDeduplicatesFrontmatter:
+    def test_full_replace_deduplicates(self, temp_vault, monkeypatch):
+        note = temp_vault / "test.md"
+        note.write_text("---\ntitle: Old\n---\n\nbody\n", encoding="utf-8")
+        monkeypatch.setattr(
+            "obsidian_mcp.tools.creation_logic.find_note_by_name",
+            lambda name: note if note.exists() else None,
+        )
+
+        dup_content = (
+            "---\n"
+            "title: New\n"
+            "created: 2026-06-09\n"
+            "type: nota\n"
+            "created: '2026-06-09'\n"
+            "---\n\n"
+            "new body\n"
+        )
+        result = edit_note("test.md", [{"old": "", "new": dup_content}])
+        assert result.success
+        content = note.read_text(encoding="utf-8")
+        assert content.count("created:") == 1
+
+    def test_partial_edit_deduplicates(self, temp_vault, monkeypatch):
+        note = temp_vault / "test.md"
+        note.write_text(
+            "---\ntitle: Test\ncreated: 2026-01-01\ncreated: '2026-01-01'\n---\n\nbody\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "obsidian_mcp.tools.creation_logic.find_note_by_name",
+            lambda name: note if note.exists() else None,
+        )
+
+        result = edit_note("test.md", [{"old": "body", "new": "changed"}])
+        assert result.success
+        content = note.read_text(encoding="utf-8")
+        assert content.count("created:") == 1


### PR DESCRIPTION
## Summary
- LLM clients sometimes emit YAML with repeated keys (e.g. two `created:` lines), producing invalid frontmatter that Obsidian flags in red
- Added `_normalize_frontmatter()` which round-trips the YAML block through `safe_load` → `dump` to guarantee unique keys
- Applied in all 3 write paths: `create_note`, `edit_note` full-replace, and `edit_note` partial

## Test plan
- [x] 9 new tests covering unit + integration (duplicate dedup, last-value-wins, body preservation, invalid YAML passthrough, create_note integration, edit_note integration)
- [x] 374 existing tests still pass (0 failures)
- [x] Manually verified fix on affected vault note (`Idea - Skill mining desde Langfuse.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)