### PR TITLE
Polish public beta launch surface

### DIFF
--- a/.github/ISSUE_TEMPLATE/beta_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/beta_feedback.yml
@@ -1,0 +1,38 @@
+name: Beta feedback
+description: Share feedback from trying the public beta.
+title: "feedback: "
+labels: ["beta-feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for rough edges, confusing flows, missing docs, or ideas from real use.
+  - type: textarea
+    id: use-case
+    attributes:
+      label: What were you trying to do?
+      placeholder: I wanted Codex to read/search/edit notes in my vault...
+    validations:
+      required: true
+  - type: dropdown
+    id: client
+    attributes:
+      label: MCP client or harness
+      options:
+        - Codex
+        - Claude Code
+        - Hermes
+        - Claude Desktop
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: friction
+    attributes:
+      label: What felt confusing or missing?
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: What would make it better?

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,43 @@
+name: Bug report
+description: Report something that is not working as expected.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for testing Obsidian MCP Server. Please avoid sharing private vault content in public issues.
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the bug and what you expected instead.
+    validations:
+      required: true
+  - type: input
+    id: client
+    attributes:
+      label: MCP client or harness
+      placeholder: Codex, Claude Code, Hermes, Claude Desktop, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Relevant configuration
+      description: Redact private paths, tokens, and vault content.
+      render: toml
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or error output
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I have removed private vault content and secrets from this report.
+          required: true
+        - label: I have checked the installation guide and troubleshooting docs.
+          required: false

--- a/.github/ISSUE_TEMPLATE/installation_help.yml
+++ b/.github/ISSUE_TEMPLATE/installation_help.yml
@@ -1,0 +1,35 @@
+name: Installation help
+description: Ask for help connecting the server to an MCP client.
+title: "install: "
+labels: ["installation", "question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening this issue, check `docs/installation.md` and `docs/troubleshooting.md`.
+  - type: dropdown
+    id: client
+    attributes:
+      label: MCP client or harness
+      options:
+        - Codex
+        - Claude Code
+        - Hermes
+        - Claude Desktop
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: MCP configuration
+      description: Redact private paths and secrets.
+      render: toml
+    validations:
+      required: true
+  - type: textarea
+    id: error
+    attributes:
+      label: Error or symptom
+    validations:
+      required: true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@ This document contains critical information about working with this codebase. Fo
    - Installation: `uv add package`
    - Running tools: `uv run tool`
    - Upgrading: `uv add --dev package --upgrade-package package`
-   - FORBIDDEN: `uv pip install`, `@latest` syntax
+   - FORBIDDEN: pip-compatible install subcommands through uv, `@latest` syntax
 
 2. Code Quality
    - Type hints required for all code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - Eliminados planes internos de desarrollo y scripts personales/backup que contenían rutas locales antes de publicar el repositorio.
 
 ### Docs
+- Pulido el README para la beta pública con instalación Git/uvx visible, ejemplo de Codex, grafo del vault y clientes actuales.
+- Añadidas plantillas de issues para bugs, ayuda de instalación y feedback de beta.
 - Añadidos documentos públicos de contribución, seguridad y checklist de release.
 - Añadida guía estándar de instalación para Claude Code, Codex, Hermes, Claude Desktop y MCPB.
 - Regla añadida en `AGENTS.md` exigiendo actualizar el `CHANGELOG.md` antes de cada commit.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,28 @@
 <br>
 [![MCP Compatible](https://img.shields.io/badge/MCP-Compatible-5c3cfa?style=flat)](https://modelcontextprotocol.io/)
 [![Obsidian Integration](https://img.shields.io/badge/Obsidian-Vault-483699?style=flat&logo=obsidian&logoColor=white)](https://obsidian.md/)
-[![Claude Desktop](https://img.shields.io/badge/Claude-Desktop-D97757?style=flat&logo=anthropic&logoColor=white)](https://claude.ai/)
+[![Claude Code](https://img.shields.io/badge/Claude-Code-D97757?style=flat&logo=anthropic&logoColor=white)](https://claude.ai/)
+[![Codex](https://img.shields.io/badge/OpenAI-Codex-10A37F?style=flat&logo=openai&logoColor=white)](https://openai.com/codex/)
 [![Custom Skills](https://img.shields.io/badge/AI-Skills-10A37F?style=flat)](https://github.com/Vasallo94/obsidian-mcp-server/blob/main/docs/agent-folder-setup.md)
 
-An **MCP (Model Context Protocol)** server that makes an Obsidian vault useful to AI clients such as Claude Desktop, Claude Code, Cursor, and Cline. It is designed as a public, reusable core with optional tool sets and vault-specific profiles layered on top.
+An **MCP (Model Context Protocol)** server that lets AI agents work inside an Obsidian vault: read notes, search context, inspect links, follow vault-specific rules, and optionally create or edit notes safely.
+
+It is designed for clients and harnesses such as **Codex**, **Claude Code**, **Hermes**, and **Claude Desktop**. The core stays reusable; each vault can layer its own profiles, rules, skills, and optional tool sets on top.
+
+> Tools are generic. Behavior comes from the vault.
+
+![Example Obsidian vault graph generated through the MCP server](docs/vault-graph.png)
+
+```mermaid
+flowchart LR
+    Clients["Codex, Claude Code, Hermes, Claude Desktop"] --> MCP["Obsidian MCP Server"]
+    MCP --> Core["Core tools: read, search, inspect, route"]
+    MCP --> Optional["Optional tool sets: write, graph, canvas, ObsidianRAG"]
+    Core --> Vault["Obsidian vault"]
+    Optional --> Vault
+    Vault --> Profile[".agents/vault.yaml, rules, skills, standards"]
+    Profile --> MCP
+```
 
 ---
 
@@ -43,55 +61,62 @@ Optional packs are enabled explicitly from `.agents/vault.yaml` or
 - **Safe by default**: Write tools are opt-in, protected paths are blocked, and large reads are capped.
 - **External RAG by integration**: Advanced semantic search delegates to ObsidianRAG instead of duplicating a RAG stack inside the MCP server.
 
-## Quick Setup
+## Quick Start
 
 ### Prerequisites
 
-- Python 3.11+
-- [uv](https://github.com/astral-sh/uv) (Recommended)
+- [uv](https://github.com/astral-sh/uv)
+- An Obsidian vault path you are comfortable exposing to an MCP client
 
-### Steps
+### Beta install from Git
 
-1. **Clone**:
+Until the package is published to PyPI, install directly from GitHub with
+`uvx`:
 
-   ```bash
-   git clone https://github.com/Vasallo94/obsidian-mcp-server.git
-   cd obsidian-mcp-server
-   ```
+```bash
+uvx --from git+https://github.com/Vasallo94/obsidian-mcp-server.git obsidian-mcp-server
+```
 
-2. **Install**:
+For Codex, add this to `~/.codex/config.toml`:
 
-   ```bash
-   make install
-   ```
+```toml
+[mcp_servers.obsidian]
+command = "uvx"
+args = [
+  "--from",
+  "git+https://github.com/Vasallo94/obsidian-mcp-server.git",
+  "obsidian-mcp-server",
+]
+startup_timeout_sec = 30
+tool_timeout_sec = 120
 
-3. **Configure**:
+[mcp_servers.obsidian.env]
+OBSIDIAN_VAULT_PATH = "/absolute/path/to/your/vault"
+```
 
-   ```bash
-   cp .env.example .env
-   # Set OBSIDIAN_VAULT_PATH to the absolute path to your Obsidian vault
-   ```
+For Claude Code, Hermes, Claude Desktop, and MCPB setup, see
+[Installation](docs/installation.md).
 
-4. **Run locally**:
+### Local development
 
-   ```bash
-   uv run obsidian-mcp-server
-   ```
+```bash
+git clone https://github.com/Vasallo94/obsidian-mcp-server.git
+cd obsidian-mcp-server
+make install
+cp .env.example .env
+# Set OBSIDIAN_VAULT_PATH to the absolute path to your Obsidian vault
+uv run obsidian-mcp-server
+```
 
-   Local runs require `OBSIDIAN_VAULT_PATH` to be configured first. For
-   end-user installation in MCP clients, prefer `uvx` once the package is
-   published:
+Once the package is published to PyPI, client configs can use:
 
-   ```bash
-   uvx obsidian-mcp-server
-   ```
+```bash
+uvx obsidian-mcp-server
+```
 
 ---
 
 ## Usage
-
-For Claude Code, Codex, Hermes, Claude Desktop, and MCPB setup, see
-[Installation](docs/installation.md).
 
 ### Optional Tool Sets
 
@@ -167,9 +192,9 @@ For contribution, release, and security process, see
 | Command | Description |
 | :--- | :--- |
 | `make test` | Run the test suite (pytest) |
-| `make lint` | Run static checks (Ruff + Mypy + Pylint) |
+| `make lint` | Run static checks (Ruff + Pyright) |
 | `make format` | Automatically format code |
-| `make dev` | Run the MCP inspector for live testing |
+| `make dev` | Run the MCP server locally |
 
 ---
 


### PR DESCRIPTION
## Summary
- Rework the README opening for public beta conversion: supported harnesses, beta install from Git, Codex config, vault graph image, and a small architecture diagram.
- Add issue templates for bug reports, beta feedback, and installation help.
- Clean public agent instructions wording and record the docs polish in the changelog.

## GitHub metadata
- Updated repository description for the public beta.
- Added discovery topics: mcp-server, obsidian-md, claude-code, codex, ai-agents, knowledge-management, second-brain, uv, fastmcp.
- Added labels: beta-feedback, installation, mcp-client, obsidianrag.

## Verification
- uv run pytest tests/test_public_distribution_contract.py
- uv run pre-commit run check-yaml --files .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/beta_feedback.yml .github/ISSUE_TEMPLATE/installation_help.yml
- public grep for stale install commands and personal paths
- pre-commit hooks during commit
