### PR TITLE
Sync public wiki docs with current MCP API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - Eliminados planes internos de desarrollo y scripts personales/backup que contenían rutas locales antes de publicar el repositorio.
 
 ### Docs
+- Reorganizada la documentación como wiki pública con `docs/index.md`, arquitectura actualizada, guía `.agents` vigente, página de semantic search con ObsidianRAG y contratos contra links rotos/nombres antiguos de tools.
 - Pulido el README para la beta pública con instalación Git/uvx visible, ejemplo de Codex, grafo del vault y clientes actuales.
 - Añadidas plantillas de issues para bugs, ayuda de instalación y feedback de beta.
 - Añadidos documentos públicos de contribución, seguridad y checklist de release.

--- a/README.md
+++ b/README.md
@@ -173,13 +173,15 @@ dependencies, starting services, pulling models, or rebuilding the index.
 
 To dive deeper into how the server works and how to customize it, check our detailed guides located in the `docs/` folder:
 
-1. [Architecture](docs/architecture.md): Modular structure and data flow of the project.
-2. [Tool Reference](docs/tool-reference.md): Complete list of available MCP tools and their parameters.
-3. [Server Configuration](docs/configuration.md): Guide on environment variables and technical configuration.
-4. [Agent Setup](docs/agent-folder-setup.md): How to organize your vault (`.agents/`) with skills and contextual rules.
-5. [Semantic Search](docs/semantic-search.md): ObsidianRAG integration and legacy RAG migration notes.
-6. [Agent Feedback](docs/agent-feedback.md): How agents can report MCP friction with AFP out-of-band.
-7. [Future Roadmap](docs/FUTURE.md): Planned improvements and next steps for the server.
+1. [Documentation Home](docs/index.md): Wiki-style map of the project docs.
+2. [Installation](docs/installation.md): Setup for Codex, Claude Code, Hermes, Claude Desktop, and MCPB.
+3. [Architecture](docs/architecture.md): Runtime architecture, tool sets, resources, prompts, and security model.
+4. [Tool Reference](docs/tool-reference.md): Complete list of public MCP tools.
+5. [Server Configuration](docs/configuration.md): Environment variables, vault profiles, tool sets, and integrations.
+6. [Agent Setup](docs/agent-folder-setup.md): How to organize your vault (`.agents/`) with skills and contextual rules.
+7. [Semantic Search](docs/semantic-search.md): ObsidianRAG integration and legacy RAG migration notes.
+8. [Agent Feedback](docs/agent-feedback.md): How agents can report MCP friction with AFP out-of-band.
+9. [Future Roadmap](docs/FUTURE.md): Planned improvements and next steps for the server.
 
 For contribution, release, and security process, see
 [CONTRIBUTING.md](CONTRIBUTING.md), [SECURITY.md](SECURITY.md), and

--- a/docs/agent-feedback/2026-05-17-recommendations.md
+++ b/docs/agent-feedback/2026-05-17-recommendations.md
@@ -2,6 +2,11 @@
 
 Recommendations from an agent that ran a heavy vault audit + cleanup session.
 
+> Historical AFP report. Some tool names in this document use the pre-namespace
+> API (`create_note`, `patch_note`, `kanvas_*`, etc.) because they describe the
+> original feedback that led to the current public names such as `notes.create`,
+> `notes.patch`, and `kanvas.start`.
+
 ## Context
 
 - **Session goal**: bootstrap a Nadir astronomy profile + audit + clean up `05_Recursos/Astrofotografía/` (21 notes + 2 project notes in `04_Proyectos/`).

--- a/docs/agent-folder-setup.md
+++ b/docs/agent-folder-setup.md
@@ -1,87 +1,184 @@
-# Agent Folder Setup Guide
+# Agent Folder Setup
 
-This guide explains how to configure the `.agents/` folder in your Obsidian vault for use with the MCP server.
-
-## Directory Structure
+The `.agents/` folder lives inside your Obsidian vault. It is optional, but it
+is the recommended way to make the MCP server behave like your vault rather than
+a generic file browser.
 
 ```text
 your-vault/
 ├── .agents/
-│   ├── vault.yaml        # (Optional) Minimal operational settings
-│   ├── REGLAS_GLOBALES.md # Agent behavior & global rules
-│   └── skills/           # Specialized agent capabilities
-│       ├── writer/
-│       │   └── SKILL.md
-│       └── researcher/
+│   ├── vault.yaml
+│   ├── REGLAS_GLOBALES.md
+│   └── skills/
+│       └── writer/
 │           └── SKILL.md
 └── ... your notes
 ```
 
-## vault.yaml (Optional)
+## What each file does
 
-Minimal operational settings. Only required if auto-detection doesn't work.
+| Path | Purpose | Exposed through |
+|---|---|---|
+| `.agents/vault.yaml` | Optional profile, tool sets, standards, integrations, private paths | `vault.health`, `vault.diagnose`, `obsidian://profile`, `obsidian://capabilities` |
+| `.agents/REGLAS_GLOBALES.md` | Global instructions and validation rules for agents | `rules.get()` |
+| `.agents/skills/<name>/SKILL.md` | Reusable agent roles or workflows | `skills.list()`, `skills.read(name)`, `obsidian://skills/{name}` |
+
+## Minimal vault.yaml
+
+Most vaults do not need a config file. Create one only when you want explicit
+tool sets, profile resources, or privacy rules.
 
 ```yaml
-# .agents/vault.yaml
 version: "1.0"
 
-# Where templates are stored (auto-detected if contains "template" or "plantilla")
-templates_folder: "06_Templates"
+templates_folder: "Templates"
 
-# Paths to protect from agent access
 private_paths:
-  - "**/Private/*"
+  - "**/Private/**"
   - "**/secrets.md"
+
+profile:
+  name: "my_vault"
+  tool_sets:
+    - "notes_write"
+    - "vault_analysis"
+  prompt_sets:
+    - "mermaid"
+  standards:
+    writing: "Standards/Writing.md"
+  local_docs:
+    index: "README.md"
 ```
 
-**If omitted**, the server:
-- Auto-detects templates folder
-- Uses `.forbidden_paths` for security
-- Works with any vault structure
+If omitted, the server:
 
-## REGLAS_GLOBALES.md
+- enables only the safe `core` tools;
+- auto-detects template folders containing `template` or `plantilla`;
+- uses `.forbidden_paths` plus built-in hidden/system exclusions;
+- still exposes `vault.context()`, `rules.get()`, and `skills.*` when those
+  files exist.
 
-Defines agent behavior. Read by `obtener_reglas_globales()`.
+## Enabling tool sets
+
+Tool sets can be enabled from the client environment:
+
+```bash
+OBSIDIAN_MCP_TOOL_SETS="notes_write,vault_analysis"
+```
+
+Or from the vault profile:
+
+```yaml
+profile:
+  tool_sets:
+    - "notes_write"
+    - "vault_analysis"
+    - "obsidianrag"
+```
+
+Use the smallest set that fits your workflow. Write tools are intentionally
+opt-in.
+
+## Global rules
+
+`REGLAS_GLOBALES.md` is read with `rules.get()`. Agents should call it near the
+start of a session, usually after `vault.context()`.
+
+Example:
 
 ```markdown
 ---
 name: global-agent-rules
-description: Mandatory protocol for all agents
+description: Mandatory protocol for agents working in this vault.
 ---
 
 # Global Rules
 
-## Critical Rules
-- Read notes before editing
-- Confirm with user before creating
+## Editing
 
-## Folder Conventions
-| Content Type | Location |
-|--------------|----------|
-| Daily notes  | 01_Daily/ |
-| Learning     | 02_Learning/ |
-| Projects     | 03_Projects/ |
+- Read a note with `notes.read()` before editing it.
+- Use `notes.patch()` for exact-match edits.
+- Use `notes.validate()` before creating or replacing a large note.
+
+## Privacy
+
+- Do not access notes tagged `#private`.
+- Ask before enabling write-heavy workflows.
 ```
 
 ## Skills
 
-Each skill is a folder with `SKILL.md`. Loaded by `listar_agentes()` and `obtener_instrucciones_agente()`.
+Each skill is a folder with a `SKILL.md` file:
+
+```text
+.agents/
+└── skills/
+    └── writer/
+        └── SKILL.md
+```
+
+Example:
 
 ```markdown
 ---
 name: writer
-description: Writing and editing assistance
-tools: ['read', 'edit', 'search']
+description: Draft and edit notes while preserving the user's voice.
+tools:
+  - notes.read
+  - notes.search
+  - notes.patch
 ---
 
-# Writer Skill
+# Writer
 
-Instructions for this specialized mode...
+Read the target note before editing. Preserve the author's tone. When changing
+text, prefer `notes.patch()` with exact `old` and `new` fragments.
 ```
 
-## No Configuration Needed
+The server validates skills and reports invalid files through:
 
-The MCP server works without any configuration:
-- Templates: auto-detected
-- Security: uses `.forbidden_paths` file
-- Behavior: from `REGLAS_GLOBALES.md` + skills
+- `skills.list()`;
+- `skills.read(name)`;
+- `obsidian://skills/list`;
+- `obsidian://skills/catalog`.
+
+## Standards and local docs
+
+Profile standards and local docs expose vault-owned documentation as MCP
+resources.
+
+```yaml
+profile:
+  standards:
+    media: "Standards/Media.md"
+    writing: "Standards/Writing.md"
+  local_docs:
+    workflows: "Docs/Workflows.md"
+```
+
+Agents can read them through:
+
+- `obsidian://standards/media`;
+- `obsidian://standards/writing`;
+- `obsidian://local_docs/workflows`.
+
+## ObsidianRAG integration
+
+Use the external ObsidianRAG service for semantic search:
+
+```yaml
+profile:
+  tool_sets:
+    - "obsidianrag"
+  integrations:
+    obsidianrag:
+      project_path: "/path/to/ObsidianRAG"
+      api_url: "http://127.0.0.1:8000"
+      env:
+        OBSIDIANRAG_LLM_MODEL: "gemma3"
+        OBSIDIANRAG_OLLAMA_EMBEDDING_MODEL: "embeddinggemma"
+```
+
+Agents should read `obsidian://integrations/obsidianrag/setup` or call
+`rag.setup_status()` before starting services, installing dependencies, pulling
+models, or rebuilding an index.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,70 +1,192 @@
-# Project Architecture
+# Architecture
 
-The **Obsidian MCP server** is designed with a modular and extensible architecture, utilizing the `FastMCP` framework to simplify compiling tools, resources, and prompts.
+Obsidian MCP Server is built around one rule:
 
-## Layer Structure
+> The repository provides generic tools. The vault provides behavior.
 
-The project is organized into the following logical layers:
+The server stays reusable by default. Vault-specific workflows live in
+`.agents/vault.yaml`, global rules, skills, standards, and local docs inside the
+user's Obsidian vault.
+
+## Runtime overview
 
 ```mermaid
-graph TD
-    A[FastMCP Server] --> B[Tools]
-    A --> C[Resources]
-    A --> D[Prompts]
-
-    subgraph Tools
-        B1[Navigation]
-        B2[Creation]
-        B3[Analysis]
-        B4[Graph]
-        B5[Agents]
-        B6[Semantic/RAG]
-        B7[YouTube]
+flowchart TB
+    subgraph Clients["MCP clients and harnesses"]
+        Codex["Codex"]
+        ClaudeCode["Claude Code"]
+        Hermes["Hermes"]
+        Desktop["Claude Desktop"]
     end
 
-    subgraph Core
-        E[Config]
-        H[Vault Config]
-        F[Utils]
-        G[Semantic Service]
+    subgraph Server["obsidian-mcp-server"]
+        Entry["server.py"]
+        Registry["tools/registry.py"]
+        Tools["Tool modules"]
+        Resources["MCP resources"]
+        Prompts["MCP prompts"]
+        Config["config.py + vault_config.py"]
+        Security["utils/security.py"]
     end
 
-    B --> Core
-    C --> Core
-    D --> Core
+    subgraph Vault["Obsidian vault"]
+        Notes["Markdown notes and Canvas files"]
+        Agents[".agents/vault.yaml"]
+        Rules[".agents/REGLAS_GLOBALES.md"]
+        Skills[".agents/skills/*/SKILL.md"]
+        Standards["Profile standards and local docs"]
+    end
+
+    subgraph External["Optional external services"]
+        ObsidianRAG["ObsidianRAG HTTP API"]
+        YouTube["YouTube transcript API"]
+    end
+
+    Clients --> Entry
+    Entry --> Registry
+    Entry --> Resources
+    Entry --> Prompts
+    Registry --> Tools
+    Tools --> Security
+    Tools --> Config
+    Config --> Agents
+    Tools --> Notes
+    Resources --> Skills
+    Resources --> Standards
+    Prompts --> Rules
+    Tools --> ObsidianRAG
+    Tools --> YouTube
 ```
 
-### 1. Server (`server.py`)
-This is the main entry point. It handles:
-- Validating your vault's path and configuration.
-- Instantiating the `FastMCP` server.
-- Orchestrating the registration of all tool modules, resources, and prompts.
+## Main entry point
 
-### 2. Tool Modules (`obsidian_mcp/tools/`)
-Each functional domain is grouped logically into its own file, ensuring easy maintenance and scalability:
-- **`navigation.py`**: Basic file reading, advanced codebase searching (ripgrep), and directory exploration.
-- **`creation.py`**: Writing notes, handling dynamic templates, section appendices, and content creation bounds.
-- **`analysis.py`**: Vault metadata auditing, taxonomy checking, and tag synchronization.
-- **`graph.py`**: Traversing note connections (backlinks, orphans, graph relationships).
-- **`agents.py`**: Reading custom skills (roles) from `{vault}/.agents/skills/` and global rules from `{vault}/.agents/REGLAS_GLOBALES.md` (these settings live seamlessly inside the vault, not the MCP server repo).
-- **`semantic.py`**: Connecting with the vector search engine.
-- **`youtube.py`**: External utility for fast fetching of video transcripts.
+`obsidian_mcp/server.py` creates the `FastMCP` server and registers:
 
-### 3. Semantic Service (`obsidian_mcp/semantic/`)
-This is an optional component (requires the `[rag]` extra dependencies) that manages:
-- **Indexing**: Converting existing text notes into vectors and storing them via `ChromaDB`.
-- **RAG (Retrieval-Augmented Generation)**: Returning context from the vault based on query cosine similarity.
-- **Metadata Management**: Differential tracking to allow partial index updates when notes change over time.
+- tool modules from `obsidian_mcp/tools/` and `obsidian_mcp/canvas/`;
+- read-only resources from `obsidian_mcp/resources/`;
+- reusable prompts from `obsidian_mcp/prompts/`.
 
-### 4. Utilities & Config (`obsidian_mcp/utils/` and config files)
-- **`config.py`**: Centralized management of `.env` environment variables using `python-dotenv`.
-- **`vault_config.py`**: Auto-detection logic for vault structure mapping and optional `.agents/vault.yaml` overrides.
-- **`utils/`**: Safe file extraction and manipulation helpers, logging configurations, string handlers, formatting, and secure sub-process interactions.
+The server uses stdio by default, so all operational logging must go to stderr.
+Stdout is reserved for the MCP protocol.
 
-## MCP Request Lifecycle
+## Tool registration
 
-1. The client (e.g., Claude Desktop, Cursor) issues a tool request with payload parameters.
-2. `FastMCP` intercepts the call, routing it to the registered handling function.
-3. The server validates that access to the specified paths in the vault is secure (preventing directory traversal outside the configured environment/ignoring `.forbidden_paths`).
-4. The tool interacts directly with the local file system or an active semantic service instance.
-5. An appropriately logged, JSON/Markdown formatted response is returned to the client logic unit.
+Public tool names are centralized in `obsidian_mcp/tools/registry.py`.
+
+Each tool has:
+
+- a stable public name such as `notes.read` or `vault.health`;
+- a title shown by MCP clients;
+- a tool set such as `core`, `notes_write`, `vault_analysis`, or `obsidianrag`;
+- read-only and idempotence annotations where relevant.
+
+Tool modules call `register_tool(mcp, "tool.name")`. The registry registers the
+tool only when its tool set is enabled.
+
+## Tool sets
+
+The `core` tool set is always enabled. Optional tool sets are enabled by either:
+
+- `OBSIDIAN_MCP_TOOL_SETS=notes_write,vault_analysis`; or
+- `.agents/vault.yaml` under `profile.tool_sets`.
+
+Available tool sets:
+
+| Tool set | Purpose |
+|---|---|
+| `core` | Health, diagnostics, context, routing, read/search, templates, skills, rules |
+| `notes_write` | Create, append, patch, replace, move, rename, delete notes |
+| `vault_analysis` | Stats, tags, backlinks, broken links, linting, graph analysis |
+| `agents_admin` | Skill generation/sync and global-rule registration |
+| `obsidianrag` | Semantic search through the external ObsidianRAG API |
+| `canvas` | Obsidian Canvas CRUD and graph operations |
+| `kanvas` | Canvas-based task workflow operations |
+| `youtube` | Transcript extraction |
+| `legacy_semantic` | Deprecated in-process semantic tools |
+| Profile-specific packs | Local workflows enabled only by a vault profile |
+
+## Resources
+
+Resources provide read-only context to agents:
+
+- `obsidian://vault_info`
+- `obsidian://capabilities`
+- `obsidian://profile`
+- `obsidian://skills/list`
+- `obsidian://skills/catalog`
+- `obsidian://skills/{name}`
+- `obsidian://standards/{name}`
+- `obsidian://local_docs/{name}`
+- `obsidian://docs/agent-quickstart`
+- `obsidian://integrations/obsidianrag/setup`
+- `obsidian://integrations/obsidianrag/config`
+
+Resources are intentionally safe summaries or declared files from the vault
+profile. Agents should prefer resources over guessing local conventions.
+
+## Prompts
+
+Core prompts are always registered:
+
+- `assistant_overview`
+- `create_structured_note`
+- `use_vault_template`
+- `explore_vault_context`
+
+Prompt packs and profile prompts are registered when the active vault declares
+them. Examples include Mermaid helpers, media workflows, runbook writing, daily
+review, weekly review, repository documentation, and changelog prompts.
+
+## Vault configuration
+
+`obsidian_mcp/vault_config.py` loads optional vault configuration from:
+
+```text
+<vault>/.agents/vault.yaml
+```
+
+Configuration can declare:
+
+- template folder overrides;
+- private paths and exclusion patterns;
+- tool sets and prompt sets;
+- profile standards and local docs;
+- integrations such as ObsidianRAG.
+
+If no `.agents/vault.yaml` exists, the server still works with the core tool set
+and auto-detected templates.
+
+## Security model
+
+All file access should flow through path validation helpers in
+`obsidian_mcp/utils/security.py` and vault utilities in `obsidian_mcp/utils/`.
+
+Security controls include:
+
+- vault-relative path validation;
+- directory traversal prevention;
+- `.forbidden_paths`;
+- private paths from `.agents/vault.yaml`;
+- output-size limits for large reads;
+- write tools disabled unless `notes_write` or another write-capable pack is
+  explicitly enabled.
+
+## Semantic search
+
+The recommended semantic path is `obsidianrag`, which calls an external
+ObsidianRAG service over loopback HTTP.
+
+The old in-process semantic stack remains behind `legacy_semantic` for backward
+compatibility. It is deprecated because it pulls ChromaDB, LangChain,
+sentence-transformers, and PyTorch into the MCP server process.
+
+See [Semantic search](semantic-search.md).
+
+## Request lifecycle
+
+1. The MCP client calls a public tool such as `notes.read`.
+2. FastMCP routes the call to the registered function.
+3. Pydantic and tool logic validate arguments.
+4. Security helpers validate vault-relative paths.
+5. The tool reads/writes the vault or calls an optional local integration.
+6. The result is returned as Markdown or structured JSON suitable for an agent.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,44 +1,58 @@
-# Configuration Guide
+# Configuration
 
-For the MCP server to function correctly, you need to configure the environment and understand the structure of the special folders the server expects to find in your vault.
+This page covers environment variables, vault profile configuration, tool sets,
+and integration settings.
+
+For client-specific snippets, see [Installation](installation.md).
 
 ## Environment Variables (.env)
 
-The `.env` file at the root of the project is essential:
+Local development can use a `.env` file at the root of this repository.
+Installed MCP clients usually set the same values in their MCP configuration.
 
 | Variable | Required | Description |
 | :--- | :---: | :--- |
 | `OBSIDIAN_VAULT_PATH` | Yes | **Absolute** path to the root folder of your Obsidian vault. |
 | `OBSIDIAN_MCP_TOOL_SETS` | No | Comma-separated optional tool sets, for example `notes_write,vault_analysis`. |
-| `LOG_LEVEL` | No | Log detail level (`INFO`, `DEBUG`, `ERROR`). Defaults to `INFO`. |
+| `OBSIDIAN_MCP_PROFILE_NAME` | No | Optional active profile name exposed to prompts/resources. |
+| `OBSIDIAN_SEARCH_TIMEOUT_SECONDS` | No | Search timeout override. |
+| `OBSIDIAN_MAX_SEARCH_RESULTS` | No | Maximum default search result count. |
+| `OBSIDIAN_CACHE_TTL_SECONDS` | No | Cache TTL for vault-derived context. |
+| `LOG_LEVEL` | No | Log detail level (`DEBUG`, `INFO`, `WARNING`, `ERROR`). Defaults to `INFO`. |
 
 Example `.env`:
 ```ini
-OBSIDIAN_VAULT_PATH="/Users/enrique/Documents/MyDigitalBrain"
+OBSIDIAN_VAULT_PATH="/absolute/path/to/your/vault"
 OBSIDIAN_MCP_TOOL_SETS="notes_write,vault_analysis"
 LOG_LEVEL="DEBUG"
 ```
 
 ## Security and Exclusions
 
-By design, the server ignores system and hidden folders to prevent information leaks or corruption of Obsidian metadata:
+By design, the server ignores system and hidden folders to prevent information
+leaks or corruption of Obsidian metadata:
+
 - `.obsidian`
 - `.git`
 - `.trash`
 - Other automatically configured directories.
 
-To protect additional folders, use the `.forbidden_paths` file at the root of the server or the `private_paths` configuration in `vault.yaml`.
+To protect additional folders, use `.forbidden_paths` or
+`private_paths` in `.agents/vault.yaml`.
 
-## Vault-Agnostic Architecture
+## Vault-agnostic behavior
 
-The server is designed to be **vault-independent**. It does not impose any mandatory folder structure and uses an intelligent auto-detection logic.
+The server does not impose a folder structure. It auto-detects templates and
+reads optional configuration from the vault.
 
 ### 1. Auto-detection
 The server automatically tries to find key folders:
 - **Templates**: It searches for any folder containing "template" or "plantilla" in its name (e.g., `ZZ_Templates`, `Templates`, `06_Templates`).
 
-### 2. Optional Configuration (`vault.yaml`)
-If you have a non-standard structure or want more granular control, you can create a `.agents/vault.yaml` file at the root of your vault:
+### Optional vault configuration
+
+Create `.agents/vault.yaml` at the root of your vault when you want explicit
+tool sets, profile resources, or integration settings:
 
 ```yaml
 # .agents/vault.yaml
@@ -71,7 +85,7 @@ profile:
         OBSIDIANRAG_LLM_MODEL: "gemma3"
 ```
 
-For a detailed guide on how to configure the `.agents/` folder, refer to the [Agent Folder Setup Guide](agent-folder-setup.md).
+For the full `.agents/` contract, see [Agent folder setup](agent-folder-setup.md).
 
 > [!WARNING]
 > Never point `OBSIDIAN_VAULT_PATH` to a folder that contains sensitive private information outside of Obsidian, as the agent could read it if it has read permissions.
@@ -84,8 +98,8 @@ profile behavior.
 
 ## Tool Sets and Client Roots
 
-The MCP server exposes a small core by default. Extra capabilities are explicit
-opt-ins:
+The MCP server exposes the `core` tool set by default. Extra capabilities are
+explicit opt-ins:
 
 - `notes_write`: note creation and mutation.
 - `vault_analysis`: stats, tags, links, backlinks, and graph helpers.
@@ -94,7 +108,7 @@ opt-ins:
 - `obsidianrag`: semantic search through the external ObsidianRAG backend.
 - `canvas` and `kanvas`: visual canvas and workflow helpers.
 - `legacy_semantic`: deprecated in-process semantic search. Prefer
-  `obsidianrag`; this pack is kept only for backwards compatibility.
+  `obsidianrag`; this pack is kept only for backward compatibility.
 
 Use `client.roots()` to inspect roots advertised by clients that support
 the MCP `roots/list` capability. This is useful during setup because an agent
@@ -102,9 +116,9 @@ can confirm which workspaces or vault folders the client has made visible.
 
 ## ObsidianRAG Guided Setup
 
-This project does not embed a second advanced RAG implementation. When semantic
-search is needed, enable the `obsidianrag` tool set and declare the local
-ObsidianRAG integration in `.agents/vault.yaml`.
+This project does not embed a second advanced RAG implementation by default.
+When semantic search is needed, enable the `obsidianrag` tool set and declare
+the local ObsidianRAG integration in `.agents/vault.yaml`.
 
 The older `legacy_semantic` tool set is deprecated because it embeds ChromaDB,
 LangChain retrievers, sentence-transformers, and PyTorch directly in the MCP
@@ -121,14 +135,15 @@ The server then exposes:
 Agents must ask for consent before installing dependencies, pulling models,
 starting local services, or rebuilding a large index.
 
-## Skills and Global Rules (in your Vault)
+## Skills and global rules
 
-The MCP server can read **skills** (AI personalities/roles) and **global rules** directly from your Obsidian vault. These files **are not in the MCP repository**, but in your personal vault.
+The MCP server can read skills and global rules directly from your vault. These
+files are not part of this repository.
 
-### Expected Structure in your Vault
+### Expected structure
 
 ```text
-Your_Vault/
+your-vault/
 ├── .agents/
 │   ├── REGLAS_GLOBALES.md      # General instructions for the assistant
 │   └── skills/
@@ -142,16 +157,17 @@ Your_Vault/
 
 ### SKILL.md Format
 
-Each skill is defined with a `SKILL.md` file containing YAML frontmatter and the prompt:
+Each skill is defined with a `SKILL.md` file containing YAML frontmatter and
+instructions:
 
 ```markdown
 ---
 name: Technical Writer
 description: Specialist in clear and concise documentation
 tools:
-  - create_note
-  - patch_note
-  - search_notes
+  - notes.read
+  - notes.search
+  - notes.patch
 ---
 
 # Instructions
@@ -174,7 +190,8 @@ You are a technical writer specializing in...
 
 ### REGLAS_GLOBALES.md
 
-This file contains instructions that apply to **all** interactions with the assistant, regardless of the active skill. For example:
+This file contains instructions that apply to all interactions with the
+assistant, regardless of the active skill. For example:
 
 ```markdown
 # Vault Global Rules

--- a/docs/examples/REGLAS_GLOBALES-example.md
+++ b/docs/examples/REGLAS_GLOBALES-example.md
@@ -21,11 +21,11 @@ description: >
 - *Exception*: Only allowed in content if semantically necessary
 
 ### 2. Golden Rule of Editing
-When using `editar_nota()`:
-1. **FIRST** read the note with `leer_nota()`
-2. Send `operaciones` as a list of `{"old": "exact text", "new": "replacement"}`
+When using `notes.patch()`:
+1. **FIRST** read the note with `notes.read()`
+2. Send `operations` as a list of `{"old": "exact text", "new": "replacement"}`
 3. `old` must be **UNIQUE** in the note — include more context if ambiguous
-4. For full replace: `[{"old": "", "new": "complete content"}]`
+4. For full-note replacement, prefer `notes.replace()` when the client supports confirmation
 
 ### 3. Access Restrictions
 - Don't access files in `.forbidden_paths`
@@ -38,11 +38,11 @@ When using `editar_nota()`:
 ### Step 1: Verify Vault Context
 ```python
 # ALWAYS run first:
-leer_contexto_vault()
+vault.context()
 ```
 
 ### Step 2: Verify Correct Location
-- Use `sugerir_ubicacion()` to confirm destination
+- Use `notes.suggest_location()` to confirm destination
 - Ask user for confirmation before creating
 
 ### Step 3: Use Real Frontmatter

--- a/docs/examples/SKILL-writer-example.md
+++ b/docs/examples/SKILL-writer-example.md
@@ -35,7 +35,7 @@ I am an extension of your creative mind. My goal is to take your raw thoughts an
 - **Clarity**: Prefer simple over complex. If you can say it in 5 words, don't use 10.
 
 ## Important Rules
-When using `editar_nota`, send `operaciones` as `{"old": "...", "new": "..."}`:
-1. `old` must be **EXACT** text from the note (read it first with `leer_nota`)
+When using `notes.patch`, send `operations` as `{"old": "...", "new": "..."}`:
+1. `old` must be **EXACT** text from the note (read it first with `notes.read`)
 2. `old` must be **UNIQUE** — include surrounding context if needed
-3. For full rewrite: `[{"old": "", "new": "complete file with YAML"}]`
+3. For full rewrite, use `notes.replace` when the client supports confirmation

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,68 @@
+# Documentation
+
+Obsidian MCP Server is a vault-native MCP server for agents. It exposes a safe
+core by default, then lets each vault opt into write tools, analysis, canvas,
+workflow, ObsidianRAG, and profile-specific behavior.
+
+Use this page as the wiki home.
+
+## Start here
+
+| Goal | Read |
+|---|---|
+| Install in Codex, Claude Code, Hermes, or Claude Desktop | [Installation](installation.md) |
+| Configure environment variables, tool sets, and profiles | [Configuration](configuration.md) |
+| Understand the `.agents/` vault folder | [Agent folder setup](agent-folder-setup.md) |
+| See every public MCP tool | [Tool reference](tool-reference.md) |
+| Orient an AI agent before it starts using the server | [Agent quickstart](agent-quickstart.md) |
+| Understand architecture and extension points | [Architecture](architecture.md) |
+| Configure semantic search through ObsidianRAG | [Semantic search](semantic-search.md) |
+| Troubleshoot common setup failures | [Troubleshooting](troubleshooting.md) |
+
+## Mental model
+
+```mermaid
+flowchart LR
+    Client["MCP client or harness"] --> Server["Obsidian MCP Server"]
+    Server --> Core["Core tools"]
+    Server --> Packs["Optional tool sets"]
+    Server --> Resources["Resources and prompts"]
+    Core --> Vault["Obsidian vault"]
+    Packs --> Vault
+    Vault --> Agents[".agents/vault.yaml, rules, skills, standards"]
+    Agents --> Server
+```
+
+The repository provides generic tools. The vault provides behavior:
+
+- `.agents/vault.yaml` declares optional tool sets, prompt sets, standards, and
+  integrations.
+- `.agents/REGLAS_GLOBALES.md` defines global instructions and validation rules.
+- `.agents/skills/<name>/SKILL.md` defines reusable agent roles.
+- Vault standards and local docs can be exposed as MCP resources.
+
+## Tool sets
+
+The server always exposes the `core` tool set. Everything else is opt-in.
+
+| Tool set | Purpose |
+|---|---|
+| `core` | Health, routing, context, read/search tools, templates, skills, rules |
+| `notes_write` | Create, append, patch, replace, move, rename, delete notes |
+| `vault_analysis` | Stats, tags, links, backlinks, local graph, linting |
+| `agents_admin` | Create/sync/suggest skills and add global rules |
+| `obsidianrag` | Semantic search through the external ObsidianRAG service |
+| `canvas` | Obsidian Canvas CRUD and graph editing |
+| `kanvas` | Canvas-based task/workflow boards |
+| `youtube` | YouTube transcript extraction |
+| `legacy_semantic` | Deprecated in-process semantic search |
+| Profile-specific packs | Local workflows enabled only by a profile |
+
+## Public beta notes
+
+- The project is public beta. Prefer explicit tool sets and conservative write
+  access while testing.
+- Do not share private vault content in issues. Redact paths, note text, and
+  personal metadata.
+- For user feedback, use the GitHub issue templates for bugs, installation help,
+  or beta feedback.

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -1,0 +1,79 @@
+# Semantic Search
+
+Semantic search is supported through the `obsidianrag` tool set.
+
+The recommended architecture is:
+
+```mermaid
+flowchart LR
+    Agent["Agent / MCP client"] --> MCP["Obsidian MCP Server"]
+    MCP --> Tools["rag.* tools"]
+    Tools --> API["ObsidianRAG HTTP API"]
+    API --> Index["Vector index"]
+    API --> Vault["Obsidian vault"]
+```
+
+## Recommended path: ObsidianRAG
+
+Enable the `obsidianrag` tool set and declare the local integration in
+`.agents/vault.yaml`:
+
+```yaml
+profile:
+  tool_sets:
+    - "obsidianrag"
+  integrations:
+    obsidianrag:
+      project_path: "/path/to/ObsidianRAG"
+      api_url: "http://127.0.0.1:8000"
+      env:
+        OBSIDIANRAG_LLM_MODEL: "gemma3"
+        OBSIDIANRAG_OLLAMA_EMBEDDING_MODEL: "embeddinggemma"
+```
+
+Available tools:
+
+| Tool | Purpose |
+|---|---|
+| `rag.setup_status()` | Diagnose project path, uv, Ollama, backend, and API health |
+| `rag.health()` | Check whether the ObsidianRAG API is reachable |
+| `rag.ask(question, session_id)` | Ask a semantic question over the vault |
+| `rag.rebuild_index()` | Trigger a rebuild through the ObsidianRAG backend |
+
+Useful resources:
+
+- `obsidian://integrations/obsidianrag/setup`
+- `obsidian://integrations/obsidianrag/config`
+
+Agents should show setup commands and ask for consent before:
+
+- installing dependencies;
+- pulling local models;
+- starting services;
+- rebuilding a large index.
+
+## Why the RAG stack is external
+
+The MCP server should remain small, fast, and easy to install. Keeping advanced
+RAG in ObsidianRAG avoids bundling a second vector database, embedding stack,
+retriever stack, and model runtime into every MCP installation.
+
+This separation also makes the failure modes cleaner:
+
+- MCP install problems stay in the MCP server.
+- Indexing/model problems stay in ObsidianRAG.
+- Agents can diagnose the boundary with `rag.setup_status()` and `rag.health()`.
+
+## Legacy semantic tools
+
+The `legacy_semantic` tool set still exists for backward compatibility:
+
+- `semantic.index`
+- `semantic.search`
+- `semantic.suggest_connections`
+
+It is disabled by default and deprecated for new deployments. It requires the
+optional `[rag]` dependency extra and loads ChromaDB, LangChain, sentence
+transformers, and PyTorch inside the MCP server process.
+
+Prefer `obsidianrag` unless you are maintaining an older local setup.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -107,7 +107,8 @@ project instead of embedding a second RAG stack inside this MCP server.
   rule in `.agents/REGLAS_GLOBALES.md` after interactive confirmation, so the
   agent never edits that file directly.
 - `youtube`: `youtube.transcript`.
-- `legacy_semantic`: deprecated in-process semantic tools, disabled by default.
+- `legacy_semantic`: deprecated in-process semantic tools, disabled by default:
+  `semantic.index`, `semantic.search`, and `semantic.suggest_connections`.
   Prefer `obsidianrag` for all new semantic-search deployments.
 - `canvas`: Obsidian Canvas read/write tools — `canvas.read` (surfaces the
   standard color legend and any board "Legend"/"Leyenda" card), `canvas.list`,
@@ -117,8 +118,13 @@ project instead of embedding a second RAG stack inside this MCP server.
   Card text is validated against the vault rules (e.g. no emojis in headings),
   just like `notes.*`. Standard colors: `"0"`=default, `"1"`=red, `"2"`=orange,
   `"3"`=yellow, `"4"`=green, `"5"`=cyan, `"6"`=purple.
-- `kanvas`: workflow/task-board tools.
-- `secundo_selebro`: personal profile tools such as `inbox.capture`.
+- `kanvas`: workflow/task-board tools — `kanvas.init`, `kanvas.status`,
+  `kanvas.task`, `kanvas.ready`, `kanvas.blocked`, `kanvas.start`,
+  `kanvas.finish`, `kanvas.pause`, `kanvas.approve`, `kanvas.complete`,
+  `kanvas.edit_task`, `kanvas.add_dependency`, `kanvas.propose_task`, and
+  `kanvas.propose_group`.
+- Profile-specific packs such as `secundo_selebro`: local tools enabled only by
+  a matching vault profile, for example `inbox.capture` and `random.concept`.
 
 ## Resources
 
@@ -141,8 +147,9 @@ Tool names follow two patterns by intent:
 
 - **Verb-first** for generic note operations: `notes.create`, `notes.read`,
   `notes.patch`, `notes.move`, `notes.delete`, `links.analyze`, `links.find_orphans`.
-- **Namespace-prefixed** for domain-specific tool families: `canvas_*` (Obsidian
-  Canvas), `kanvas_*` (workflow boards), `rag_*` / `rag.ask` (semantic search).
+- **Namespace-prefixed** for domain-specific tool families: `canvas.*`
+  (Obsidian Canvas), `kanvas.*` (workflow boards), and `rag.*`
+  (semantic search).
 
 Renaming public tools is a breaking change for MCP clients, so the mix is
 intentional. When in doubt, search this reference first; the function-name

--- a/tests/test_public_distribution_contract.py
+++ b/tests/test_public_distribution_contract.py
@@ -10,13 +10,33 @@ from pathlib import Path
 
 PUBLIC_GUIDANCE_PATHS = [
     Path("README.md"),
+    Path("docs/index.md"),
+    Path("docs/architecture.md"),
     Path("docs/configuration.md"),
+    Path("docs/agent-folder-setup.md"),
+    Path("docs/tool-reference.md"),
+    Path("docs/semantic-search.md"),
     Path("docs/troubleshooting.md"),
     Path("docs/installation.md"),
     Path("CONTRIBUTING.md"),
     Path("SECURITY.md"),
     Path("docs/release-checklist.md"),
     Path("scripts/diagnose.py"),
+]
+
+CURRENT_DOC_PATHS = [
+    Path("README.md"),
+    Path("docs/index.md"),
+    Path("docs/architecture.md"),
+    Path("docs/configuration.md"),
+    Path("docs/agent-folder-setup.md"),
+    Path("docs/agent-quickstart.md"),
+    Path("docs/tool-reference.md"),
+    Path("docs/semantic-search.md"),
+    Path("docs/troubleshooting.md"),
+    Path("docs/installation.md"),
+    Path("docs/examples/REGLAS_GLOBALES-example.md"),
+    Path("docs/examples/SKILL-writer-example.md"),
 ]
 
 
@@ -83,6 +103,58 @@ def test_public_docs_do_not_reference_missing_python_scripts() -> None:
         script_path for script_path in script_paths if not Path(script_path).exists()
     )
     assert missing_scripts == []
+
+
+def test_public_markdown_links_point_to_existing_files() -> None:
+    markdown_paths = [
+        Path("README.md"),
+        *sorted(Path("docs").rglob("*.md")),
+    ]
+    missing_links: list[str] = []
+
+    for path in markdown_paths:
+        text = path.read_text(encoding="utf-8")
+        for raw_target in re.findall(r"\[[^\]]+\]\(([^)#][^)]+)\)", text):
+            if "://" in raw_target or raw_target.startswith("mailto:"):
+                continue
+            target = raw_target.split("#", maxsplit=1)[0]
+            if not target or target.startswith("<"):
+                continue
+            resolved = (path.parent / target).resolve()
+            if not resolved.exists():
+                missing_links.append(f"{path}: {raw_target}")
+
+    assert not missing_links
+
+
+def test_current_docs_use_public_tool_names_not_legacy_spanish_names() -> None:
+    docs = "\n".join(path.read_text(encoding="utf-8") for path in CURRENT_DOC_PATHS)
+
+    forbidden_terms = [
+        "editar_nota",
+        "crear_nota",
+        "leer_nota",
+        "leer_contexto_vault",
+        "sugerir_ubicacion",
+        "listar_agentes",
+        "obtener_instrucciones_agente",
+        "obtener_reglas_globales",
+        "create_note",
+        "patch_note",
+        "search_notes",
+    ]
+
+    leaked_terms = [term for term in forbidden_terms if term in docs]
+    assert leaked_terms == []
+
+
+def test_tool_reference_mentions_every_registered_public_tool() -> None:
+    from obsidian_mcp.tools.registry import TOOL_SPECS
+
+    text = Path("docs/tool-reference.md").read_text(encoding="utf-8")
+    missing_tools = sorted(name for name in TOOL_SPECS if name not in text)
+
+    assert missing_tools == []
 
 
 def test_mcpb_docs_describe_release_artifacts_and_prerelease_git_install() -> None:


### PR DESCRIPTION
## Summary
- Add `docs/index.md` as a wiki-style documentation home and restore `docs/semantic-search.md` with the current ObsidianRAG-first architecture.
- Rewrite architecture and `.agents` setup docs around the current registry/tool-set/resource/prompt model.
- Replace legacy Spanish/pre-namespace tool examples with current public names such as `notes.read`, `notes.patch`, `vault.context`, and `notes.suggest_location`.
- Add documentation contracts for broken Markdown links, stale tool names, and `tool-reference.md` coverage against the real tool registry.

## Verification
- uv run ruff check .
- uv run ruff format --check .
- uv run pyright
- uv run pytest tests/
- uv build --sdist --wheel
- pre-commit hooks during commit
