### PR TITLE
fix(safety): close residual bulk-write gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - **Indexación Semántica de Imágenes**: El sistema ahora extrae descripciones de imágenes (`![[img|desc]]` o `![desc](img)`) y las inyecta como contexto semántico, haciendo buscable el contenido visual.
 
 ### Fixed
+- **Bulk write safety and public contracts**: Global replacements now re-read each note immediately before writing, report when the file limit truncates results, and note moves report partial success if wikilink rewriting fails. Public tool signatures now match registered schemas, and the vault bootstrap prompt no longer instructs agents to commit or push.
 - **Crash-safe writes and Canvas confirmation**: Vault text and Canvas files now use same-directory atomic replacement so failed writes preserve the previous file. New files default to owner-only permissions while existing permissions are preserved. Destructive `canvas.remove_card`, `canvas.remove_group`, and `canvas.remove_edge` calls now require `confirm=True`.
 - **Vault filesystem boundary**: Canvas/Kanvas, note creation, skill generation, templates, configured documents, search, analysis, graph, context, wikilink, and legacy semantic operations now canonicalize paths, reject traversal and symlink escapes, and consistently skip protected files. Vault `.forbidden_paths` entries are merged with defaults shipped inside the package.
 - **Test isolation**: The default test suite now uses a generated temporary vault instead of loading or traversing the developer's configured vault.

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -17,7 +17,7 @@ After those two calls you have enough context to write correctly. Everything bel
 | Read one note | `notes.read(note_path)` |
 | Read several notes | `notes.read_many(paths=[...])` — note: `paths`, not `query=` |
 | Search by text | `notes.search(query=, titles_only=False)` |
-| Search by date | `notes.search_by_date(date_from, date_to)` |
+| Search by date | `notes.search_by_date(start_date, end_date)` |
 | Create a note | `notes.create(title, content, folder, tags, ...)` — embed YAML frontmatter in `content` and it'll be merged with parameters |
 | Lint a note before writing | `notes.validate(content, title, mode='create')` — pre-flight, no write |
 | Edit fragments of a note | `notes.patch(note_path, operations=[{old, new}, ...])` — fuzzy suggestions on miss |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,6 +111,7 @@ Resources provide read-only context to agents:
 
 - `obsidian://vault_info`
 - `obsidian://capabilities`
+- `obsidian://vault_info`
 - `obsidian://profile`
 - `obsidian://skills/list`
 - `obsidian://skills/catalog`
@@ -132,6 +133,7 @@ Core prompts are always registered:
 - `create_structured_note`
 - `use_vault_template`
 - `explore_vault_context`
+- `bootstrap_vault_config`
 
 Prompt packs and profile prompts are registered when the active vault declares
 them. Examples include Mermaid helpers, media workflows, runbook writing, daily

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,7 +111,6 @@ Resources provide read-only context to agents:
 
 - `obsidian://vault_info`
 - `obsidian://capabilities`
-- `obsidian://vault_info`
 - `obsidian://profile`
 - `obsidian://skills/list`
 - `obsidian://skills/catalog`

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -20,7 +20,7 @@ Always enabled.
   results exist.
 - `notes.read(note_path)`: Read one note, with path checks and output limits.
 - `notes.search(query, folder, titles_only)`: Search titles or Markdown content.
-- `notes.search_by_date(date_from, date_to)`: Find recently modified notes.
+- `notes.search_by_date(start_date, end_date)`: Find notes modified in a date range; `end_date` is optional.
 - `notes.read_many(paths)`: Batch-read notes with a response-size guard. `paths` is
   a list of vault-relative paths (one Pydantic argument, not `query=`).
 - `notes.info(paths)`: Return metadata without full note content.
@@ -50,20 +50,20 @@ Optional tools are enabled from `.agents/vault.yaml` with
 ### `notes_write`
 
 - `notes.suggest_location(title, content, tags)`: Suggest a vault folder.
-- `notes.create(title, content, folder, tags, template, created_by)`: Create a note.
+- `notes.create(title, content, folder, tags, template, creator, description)`: Create a note.
   `tags` is a comma-separated string (e.g. `"astro, equipo"`); it is normalized
   to a YAML list in the saved frontmatter. If `content` already starts with a
   `---...---` frontmatter block, embedded fields (`type`, `status`, custom keys)
   are preserved; conflicts with explicit parameters resolve in favour of the
   embedded frontmatter.
-- `notes.append(note_path, content, at_end)`: Append or prepend content.
+- `notes.append(note_path, content, position, section, create_section)`: Append, prepend, or add content to a section.
 - `notes.patch(note_path, operations)`: Apply atomic exact-match edits with
   operations shaped as `{"old": "...", "new": "..."}`. Compatibility aliases
   `oldText`/`newText` and `old_text`/`new_text` are accepted, but clients
   should prefer `old`/`new`.
-- `notes.replace(note_path, content)`: Replace a full note.
-- `notes.update_frontmatter(note_path, updates)`: Update YAML frontmatter.
-- `notes.update_tags(note_path, tags)`: Update tag metadata.
+- `notes.replace(note_path, content, confirm)`: Replace a full note after explicit confirmation.
+- `notes.update_frontmatter(note_path, frontmatter_updates, merge)`: Update YAML frontmatter from a JSON string.
+- `notes.update_tags(note_path, operation, tags)`: Add, remove, or list tag metadata.
 - `notes.move(source, destination, create_folders, update_links)`: Move or
   rename a note. When `update_links=True`, every vault wikilink targeting
   the old stem is rewritten to the new stem (aliases/sections preserved).
@@ -74,7 +74,7 @@ Optional tools are enabled from `.agents/vault.yaml` with
   stem (without `.md`), or as a path to also move folders.
 - `notes.delete(note_path, confirm)`: Delete a note after explicit confirmation.
 - `notes.preview_replace(...)`: Preview global replacements.
-- `notes.apply_replace(...)`: Apply global replacements; always run the preview first.
+- `notes.apply_replace(search, replacement, folder, limit, confirm)`: Apply global replacements after explicit confirmation; always run the preview first.
 
 ### `vault_analysis`
 
@@ -142,6 +142,7 @@ project instead of embedding a second RAG stack inside this MCP server.
   every new session). Two-call boot sequence, decision table mapping
   intent -> tool, and common pitfalls.
 - `obsidian://capabilities`: Active prompts, tool sets, resources, and integrations.
+- `obsidian://vault_info`: Basic vault identity and size information.
 - `obsidian://profile`: Safe active profile summary.
 - `obsidian://skills/list`: Valid and invalid vault skills.
 - `obsidian://skills/catalog`: Skills with use-case hints.

--- a/obsidian_mcp/prompts/core.py
+++ b/obsidian_mcp/prompts/core.py
@@ -173,6 +173,7 @@ def register_core_prompts(mcp: FastMCP) -> None:
 
         Deliverable: write the file, then produce a short markdown report of
         what you inferred (roles → folders, type vocabulary, tag registry
-        path, and anything ambiguous you had to guess). Commit both the
-        `vault.yaml` and the report, and push.
+        path, and anything ambiguous you had to guess). Show the resulting
+        `vault.yaml` and report to the user. Do not commit or push; leave that
+        decision to the user.
         """

--- a/obsidian_mcp/tools/creation_logic.py
+++ b/obsidian_mcp/tools/creation_logic.py
@@ -1016,6 +1016,7 @@ def search_and_replace_global(
     # Buscar archivos .md
     archivos_afectados: list[dict[str, Any]] = []
     limite_alcanzado = False
+    archivos_omitidos = 0
 
     for md_file in iter_safe_vault_files(vault_path, root=search_path):
         # Saltar carpetas excluidas
@@ -1045,12 +1046,16 @@ def search_and_replace_global(
                     }
                 )
 
-        except OSError as e:
+        except (OSError, UnicodeDecodeError) as e:
+            archivos_omitidos += 1
             logger.debug("No se pudo leer '%s' para busqueda: %s", md_file, e)
             continue
 
     if not archivos_afectados:
-        return Result.ok(f"ℹ️ No se encontró '{buscar}' en ninguna nota.")
+        resultado = f"ℹ️ No se encontró '{buscar}' en ninguna nota."
+        if archivos_omitidos:
+            resultado += f"\n⚠️ Archivos ilegibles omitidos: {archivos_omitidos}."
+        return Result.ok(resultado)
 
     # Modo preview
     if solo_preview:
@@ -1068,11 +1073,14 @@ def search_and_replace_global(
                 f"\n⚠️ Límite de {limite} archivos alcanzado; "
                 "puede haber más coincidencias.\n"
             )
+        if archivos_omitidos:
+            resultado += f"\n⚠️ Archivos ilegibles omitidos: {archivos_omitidos}.\n"
         resultado += "\n⚠️ Usa `notes.apply_replace` para aplicar los cambios."
         return Result.ok(resultado)
 
     # Modo ejecución
     archivos_modificados = 0
+    archivos_sin_coincidencia = 0
     total_reemplazos = 0
 
     for arch in archivos_afectados:
@@ -1080,19 +1088,25 @@ def search_and_replace_global(
             contenido_actual = arch["path"].read_text(encoding="utf-8")
             ocurrencias = contenido_actual.count(buscar)
             if not ocurrencias:
+                archivos_sin_coincidencia += 1
                 continue
             nuevo_contenido = contenido_actual.replace(buscar, reemplazar)
             atomic_write_text(arch["path"], nuevo_contenido)
             archivos_modificados += 1
             total_reemplazos += ocurrencias
-        except OSError as e:
-            logger.warning("No se pudo escribir reemplazo en '%s': %s", arch["path"], e)
+        except (OSError, UnicodeDecodeError) as e:
+            archivos_omitidos += 1
+            logger.warning("No se pudo reemplazar en '%s': %s", arch["path"], e)
             continue
 
     resultado = "✅ **Reemplazo completado**\n"
     resultado += f"- Archivos modificados: {archivos_modificados}\n"
     resultado += f"- Reemplazos realizados: {total_reemplazos}\n"
     resultado += f"- `{buscar}` → `{reemplazar}`"
+    if archivos_sin_coincidencia:
+        resultado += f"\n- Archivos ya sin coincidencias: {archivos_sin_coincidencia}"
+    if archivos_omitidos:
+        resultado += f"\n⚠️ Archivos ilegibles o no escritos: {archivos_omitidos}."
     if limite_alcanzado:
         resultado += (
             f"\n⚠️ Límite de {limite} archivos alcanzado; puede haber más coincidencias."

--- a/obsidian_mcp/tools/creation_logic.py
+++ b/obsidian_mcp/tools/creation_logic.py
@@ -976,7 +976,7 @@ def search_and_replace_global(
     solo_preview: bool = True,
     limite: int = 100,
 ) -> Result[str]:
-    # pylint: disable=too-many-branches,too-many-locals
+    # pylint: disable=too-many-branches,too-many-locals,too-many-statements
     """Search and replace text in all notes.
 
     Args:
@@ -995,6 +995,8 @@ def search_and_replace_global(
 
     if not buscar:
         return Result.fail("Debes especificar un texto a buscar.")
+    if limite < 1:
+        return Result.fail("El límite debe ser al menos 1.")
 
     # Determinar carpeta de búsqueda
     search_path, error = resolve_vault_path(
@@ -1013,7 +1015,7 @@ def search_and_replace_global(
 
     # Buscar archivos .md
     archivos_afectados: list[dict[str, Any]] = []
-    archivos_procesados = 0
+    limite_alcanzado = False
 
     for md_file in iter_safe_vault_files(vault_path, root=search_path):
         # Saltar carpetas excluidas
@@ -1030,6 +1032,9 @@ def search_and_replace_global(
                 contenido = f.read()
 
             if buscar in contenido:
+                if len(archivos_afectados) >= limite:
+                    limite_alcanzado = True
+                    break
                 ocurrencias = contenido.count(buscar)
                 ruta_rel = md_file.relative_to(vault_path)
                 archivos_afectados.append(
@@ -1037,13 +1042,8 @@ def search_and_replace_global(
                         "path": md_file,
                         "ruta_rel": str(ruta_rel),
                         "ocurrencias": ocurrencias,
-                        "contenido_original": contenido,
                     }
                 )
-
-                archivos_procesados += 1
-                if archivos_procesados >= limite:
-                    break
 
         except OSError as e:
             logger.debug("No se pudo leer '%s' para busqueda: %s", md_file, e)
@@ -1063,6 +1063,11 @@ def search_and_replace_global(
             resultado += f"- `{arch['ruta_rel']}` ({arch['ocurrencias']} ocurrencias)\n"
         if len(archivos_afectados) > 20:
             resultado += f"- ... y {len(archivos_afectados) - 20} archivos más\n"
+        if limite_alcanzado:
+            resultado += (
+                f"\n⚠️ Límite de {limite} archivos alcanzado; "
+                "puede haber más coincidencias.\n"
+            )
         resultado += "\n⚠️ Usa `notes.apply_replace` para aplicar los cambios."
         return Result.ok(resultado)
 
@@ -1072,10 +1077,14 @@ def search_and_replace_global(
 
     for arch in archivos_afectados:
         try:
-            nuevo_contenido = arch["contenido_original"].replace(buscar, reemplazar)
+            contenido_actual = arch["path"].read_text(encoding="utf-8")
+            ocurrencias = contenido_actual.count(buscar)
+            if not ocurrencias:
+                continue
+            nuevo_contenido = contenido_actual.replace(buscar, reemplazar)
             atomic_write_text(arch["path"], nuevo_contenido)
             archivos_modificados += 1
-            total_reemplazos += arch["ocurrencias"]
+            total_reemplazos += ocurrencias
         except OSError as e:
             logger.warning("No se pudo escribir reemplazo en '%s': %s", arch["path"], e)
             continue
@@ -1084,6 +1093,10 @@ def search_and_replace_global(
     resultado += f"- Archivos modificados: {archivos_modificados}\n"
     resultado += f"- Reemplazos realizados: {total_reemplazos}\n"
     resultado += f"- `{buscar}` → `{reemplazar}`"
+    if limite_alcanzado:
+        resultado += (
+            f"\n⚠️ Límite de {limite} archivos alcanzado; puede haber más coincidencias."
+        )
     return Result.ok(resultado)
 
 

--- a/obsidian_mcp/tools/navigation_logic.py
+++ b/obsidian_mcp/tools/navigation_logic.py
@@ -379,10 +379,17 @@ def move_note(  # pylint: disable=too-many-locals,too-many-return-statements
     msg = f"File moved/renamed:\nFrom: {origen}\nTo:   {destino}"
 
     if update_links and old_stem != new_stem:
-        total, touched = rewrite_wikilinks_in_vault(
-            vault_path, old_target=old_stem, new_target=new_stem
-        )
-        msg += f"\nLinks updated: {total} references across {len(touched)} files."
+        try:
+            total, touched = rewrite_wikilinks_in_vault(
+                vault_path, old_target=old_stem, new_target=new_stem
+            )
+            msg += f"\nLinks updated: {total} references across {len(touched)} files."
+        except OSError as exc:
+            msg += (
+                "\nWarning: the note was moved, but wikilink updates stopped after "
+                f"a write error ({exc}). Some links may already be updated; run "
+                "links.find_broken and repair any remaining old targets."
+            )
     elif not update_links:
         # Issue #11: surface impact even when we didn't rewrite.
         total, touched = rewrite_wikilinks_in_vault(

--- a/obsidian_mcp/tools/navigation_logic.py
+++ b/obsidian_mcp/tools/navigation_logic.py
@@ -378,28 +378,30 @@ def move_note(  # pylint: disable=too-many-locals,too-many-return-statements
 
     msg = f"File moved/renamed:\nFrom: {origen}\nTo:   {destino}"
 
-    if update_links and old_stem != new_stem:
-        try:
+    try:
+        if update_links and old_stem != new_stem:
             total, touched = rewrite_wikilinks_in_vault(
                 vault_path, old_target=old_stem, new_target=new_stem
             )
             msg += f"\nLinks updated: {total} references across {len(touched)} files."
-        except OSError as exc:
-            msg += (
-                "\nWarning: the note was moved, but wikilink updates stopped after "
-                f"a write error ({exc}). Some links may already be updated; run "
-                "links.find_broken and repair any remaining old targets."
+        elif not update_links:
+            # Issue #11: surface impact even when we didn't rewrite.
+            total, touched = rewrite_wikilinks_in_vault(
+                vault_path, old_target=old_stem, new_target=new_stem, dry_run=True
             )
-    elif not update_links:
-        # Issue #11: surface impact even when we didn't rewrite.
-        total, touched = rewrite_wikilinks_in_vault(
-            vault_path, old_target=old_stem, new_target=new_stem, dry_run=True
+            if old_stem != new_stem and total > 0:
+                msg += (
+                    f"\nWarning: {total} wikilinks across {len(touched)} files now "
+                    f"point to the old stem '{old_stem}'. Re-run with "
+                    "update_links=True to fix."
+                )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        # The rename already happened, so never report the whole move as failed.
+        msg += (
+            "\nWarning: the note was moved, but wikilink handling stopped after "
+            f"an error ({exc}). Some links may already be updated; run "
+            "links.find_broken and repair any remaining old targets."
         )
-        if old_stem != new_stem and total > 0:
-            msg += (
-                f"\nWarning: {total} wikilinks across {len(touched)} files now point "
-                f"to the old stem '{old_stem}'. Re-run with update_links=True to fix."
-            )
 
     return Result.ok(msg)
 

--- a/obsidian_mcp/utils/wikilinks.py
+++ b/obsidian_mcp/utils/wikilinks.py
@@ -140,7 +140,7 @@ def scan_broken_wikilinks(vault_path: Path) -> list[BrokenWikilink]:
     for md_file in iter_safe_vault_files(vault_path):
         try:
             content = md_file.read_text(encoding="utf-8")
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
         for occ in iter_wikilinks(content, md_file):
             if target_resolves(occ.target, stem_index, vault_path):
@@ -209,7 +209,7 @@ def rewrite_wikilinks_in_vault(
     for md_file in iter_safe_vault_files(vault_path):
         try:
             content = md_file.read_text(encoding="utf-8")
-        except OSError:
+        except (OSError, UnicodeDecodeError):
             continue
         new_content, count = rewrite_wikilinks_in_content(
             content, old_target=old_target, new_target=new_target

--- a/tests/test_afp_dogfood_regressions.py
+++ b/tests/test_afp_dogfood_regressions.py
@@ -8,6 +8,7 @@ import yaml
 from obsidian_mcp.config import reset_settings
 from obsidian_mcp.middleware import invalidate_rules_cache
 from obsidian_mcp.server import create_server
+from obsidian_mcp.tools import creation_logic
 from obsidian_mcp.tools.analysis_logic import sync_tag_registry
 from obsidian_mcp.tools.creation_logic import (
     search_and_replace_global,
@@ -77,6 +78,38 @@ def test_preview_replace_points_agents_to_apply_replace(tmp_path, monkeypatch):
     assert result.success
     assert "notes.apply_replace" in result.data
     assert "solo_preview=False" not in result.data
+
+
+def test_apply_replace_rereads_before_writing(tmp_path, monkeypatch):
+    vault = _set_vault(monkeypatch, tmp_path)
+    note = vault / "note.md"
+    note.write_text("target original", encoding="utf-8")
+
+    def mutate_after_scan(*_args, **_kwargs):
+        yield note
+        note.write_text("target original plus user edit", encoding="utf-8")
+
+    monkeypatch.setattr(creation_logic, "iter_safe_vault_files", mutate_after_scan)
+
+    result = search_and_replace_global("target", "replacement", solo_preview=False)
+
+    assert result.success
+    assert note.read_text(encoding="utf-8") == "replacement original plus user edit"
+
+
+def test_replace_reports_when_file_limit_truncates_results(tmp_path, monkeypatch):
+    vault = _set_vault(monkeypatch, tmp_path)
+    for index in range(3):
+        (vault / f"note-{index}.md").write_text("target", encoding="utf-8")
+
+    preview = search_and_replace_global("target", "replacement", limite=2)
+    applied = search_and_replace_global(
+        "target", "replacement", solo_preview=False, limite=2
+    )
+
+    assert preview.success and applied.success
+    assert "Límite de 2 archivos alcanzado" in (preview.data or "")
+    assert "Límite de 2 archivos alcanzado" in (applied.data or "")
 
 
 def test_update_frontmatter_rejects_json_that_is_not_an_object(tmp_path, monkeypatch):

--- a/tests/test_afp_dogfood_regressions.py
+++ b/tests/test_afp_dogfood_regressions.py
@@ -97,6 +97,38 @@ def test_apply_replace_rereads_before_writing(tmp_path, monkeypatch):
     assert note.read_text(encoding="utf-8") == "replacement original plus user edit"
 
 
+def test_apply_replace_reports_file_that_becomes_non_utf8(tmp_path, monkeypatch):
+    vault = _set_vault(monkeypatch, tmp_path)
+    first = vault / "a.md"
+    changed = vault / "b.md"
+    first.write_text("target", encoding="utf-8")
+    changed.write_text("target", encoding="utf-8")
+
+    def mutate_after_scan(*_args, **_kwargs):
+        yield first
+        yield changed
+        changed.write_bytes(b"\xff\xfe")
+
+    monkeypatch.setattr(creation_logic, "iter_safe_vault_files", mutate_after_scan)
+
+    result = search_and_replace_global("target", "replacement", solo_preview=False)
+
+    assert result.success
+    assert first.read_text(encoding="utf-8") == "replacement"
+    assert changed.read_bytes() == b"\xff\xfe"
+    assert "Archivos ilegibles o no escritos: 1" in (result.data or "")
+
+
+def test_preview_replace_reports_non_utf8_file(tmp_path, monkeypatch):
+    vault = _set_vault(monkeypatch, tmp_path)
+    (vault / "legacy.md").write_bytes(b"\xff\xfe")
+
+    result = search_and_replace_global("target", "replacement")
+
+    assert result.success
+    assert "Archivos ilegibles omitidos: 1" in (result.data or "")
+
+
 def test_replace_reports_when_file_limit_truncates_results(tmp_path, monkeypatch):
     vault = _set_vault(monkeypatch, tmp_path)
     for index in range(3):

--- a/tests/test_profile_prompts_resources.py
+++ b/tests/test_profile_prompts_resources.py
@@ -33,12 +33,14 @@ def test_core_prompts_register_without_vault_profile(tmp_path, monkeypatch):
 
     prompt_names = {prompt.name for prompt in asyncio.run(mcp.list_prompts())}
     tool_names = {tool.name for tool in asyncio.run(mcp.list_tools())}
+    bootstrap_prompt = asyncio.run(mcp.get_prompt("bootstrap_vault_config")).fn()
 
     assert {
         "assistant_overview",
         "create_structured_note",
         "use_vault_template",
         "explore_vault_context",
+        "bootstrap_vault_config",
     }.issubset(prompt_names)
     assert "create_mermaid_diagram" not in prompt_names
     assert "update_media_item" not in prompt_names
@@ -47,6 +49,8 @@ def test_core_prompts_register_without_vault_profile(tmp_path, monkeypatch):
     assert "rag.ask" not in tool_names
     assert "rag.health" not in tool_names
     assert "preguntar_al_conocimiento" not in tool_names
+    assert "Do not commit or push" in bootstrap_prompt
+    assert "and push" not in bootstrap_prompt
 
 
 def test_profile_and_pack_prompts_register_from_vault_config(tmp_path, monkeypatch):

--- a/tests/test_public_distribution_contract.py
+++ b/tests/test_public_distribution_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
 import subprocess
 import tarfile
@@ -167,6 +168,34 @@ def test_tool_reference_mentions_every_registered_public_tool() -> None:
     missing_tools = sorted(name for name in TOOL_SPECS if name not in text)
 
     assert missing_tools == []
+
+
+def test_documented_tool_arguments_exist_in_registered_schemas(monkeypatch) -> None:
+    from obsidian_mcp.config import reset_settings
+    from obsidian_mcp.server import create_server
+
+    monkeypatch.setenv(
+        "OBSIDIAN_MCP_TOOL_SETS",
+        "notes_write,vault_analysis,secundo_selebro,agents_admin,"
+        "youtube,obsidianrag,canvas,kanvas",
+    )
+    reset_settings()
+    mcp = create_server()
+    tools = {tool.name: tool for tool in asyncio.run(mcp.list_tools())}
+    docs = Path("docs/tool-reference.md").read_text(encoding="utf-8")
+    invalid: list[str] = []
+
+    for tool_name, raw_arguments in re.findall(r"`([a-z_.]+)\(([^)]*)\)`", docs):
+        tool = tools.get(tool_name)
+        if tool is None:
+            continue
+        schema_arguments = set(tool.parameters.get("properties", {}))
+        for raw_argument in raw_arguments.split(","):
+            match = re.match(r"\s*([A-Za-z_]\w*)", raw_argument)
+            if match and match.group(1) not in schema_arguments:
+                invalid.append(f"{tool_name}: {match.group(1)}")
+
+    assert not invalid
 
 
 def test_mcpb_docs_describe_release_artifacts_and_prerelease_git_install() -> None:

--- a/tests/test_public_distribution_contract.py
+++ b/tests/test_public_distribution_contract.py
@@ -173,11 +173,10 @@ def test_tool_reference_mentions_every_registered_public_tool() -> None:
 def test_documented_tool_arguments_exist_in_registered_schemas(monkeypatch) -> None:
     from obsidian_mcp.config import reset_settings
     from obsidian_mcp.server import create_server
+    from obsidian_mcp.tools.registry import available_tool_sets
 
     monkeypatch.setenv(
-        "OBSIDIAN_MCP_TOOL_SETS",
-        "notes_write,vault_analysis,secundo_selebro,agents_admin,"
-        "youtube,obsidianrag,canvas,kanvas",
+        "OBSIDIAN_MCP_TOOL_SETS", ",".join(sorted(available_tool_sets()))
     )
     reset_settings()
     mcp = create_server()
@@ -188,6 +187,7 @@ def test_documented_tool_arguments_exist_in_registered_schemas(monkeypatch) -> N
     for tool_name, raw_arguments in re.findall(r"`([a-z_.]+)\(([^)]*)\)`", docs):
         tool = tools.get(tool_name)
         if tool is None:
+            invalid.append(f"{tool_name}: tool not registered")
             continue
         schema_arguments = set(tool.parameters.get("properties", {}))
         for raw_argument in raw_arguments.split(","):

--- a/tests/test_wikilink_tools.py
+++ b/tests/test_wikilink_tools.py
@@ -5,6 +5,7 @@ import pytest
 from obsidian_mcp.config import reset_settings
 from obsidian_mcp.tools.analysis_logic import find_broken_wikilinks
 from obsidian_mcp.tools.navigation_logic import move_note
+from obsidian_mcp.utils import wikilinks
 
 
 @pytest.fixture
@@ -69,6 +70,20 @@ class TestMoveNoteUpdateLinks:
         assert "[[Beta]]" in a_content
         assert "[[B]]" not in a_content
         assert "Links updated:" in result.data
+
+    def test_reports_partial_success_when_link_rewrite_fails(self, vault, monkeypatch):
+        def fail_rewrite(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(wikilinks, "rewrite_wikilinks_in_vault", fail_rewrite)
+
+        result = move_note("B.md", "Beta.md", update_links=True)
+
+        assert result.success
+        assert not (vault / "B.md").exists()
+        assert (vault / "Beta.md").exists()
+        assert "note was moved" in (result.data or "")
+        assert "links.find_broken" in (result.data or "")
 
     def test_warns_when_links_left_stale(self, vault):
         """Issue #11: default move surfaces unresolved references count."""

--- a/tests/test_wikilink_tools.py
+++ b/tests/test_wikilink_tools.py
@@ -58,6 +58,14 @@ class TestFindBrokenWikilinks:
         assert result.success
         assert "mas" in result.data or "más" in result.data or "1 (" in result.data
 
+    def test_skips_non_utf8_notes(self, vault):
+        (vault / "legacy.md").write_bytes(b"\xff\xfe")
+
+        result = find_broken_wikilinks()
+
+        assert result.success
+        assert "Missing" in (result.data or "")
+
 
 class TestMoveNoteUpdateLinks:
     """Issues #7 and #11."""
@@ -71,19 +79,32 @@ class TestMoveNoteUpdateLinks:
         assert "[[B]]" not in a_content
         assert "Links updated:" in result.data
 
-    def test_reports_partial_success_when_link_rewrite_fails(self, vault, monkeypatch):
+    @pytest.mark.parametrize("update_links", [False, True])
+    def test_reports_partial_success_when_link_handling_fails(
+        self, vault, monkeypatch, update_links
+    ):
         def fail_rewrite(*_args, **_kwargs):
-            raise OSError("disk full")
+            raise ValueError("unexpected failure")
 
         monkeypatch.setattr(wikilinks, "rewrite_wikilinks_in_vault", fail_rewrite)
 
-        result = move_note("B.md", "Beta.md", update_links=True)
+        result = move_note("B.md", "Beta.md", update_links=update_links)
 
         assert result.success
         assert not (vault / "B.md").exists()
         assert (vault / "Beta.md").exists()
         assert "note was moved" in (result.data or "")
         assert "links.find_broken" in (result.data or "")
+
+    @pytest.mark.parametrize("update_links", [False, True])
+    def test_move_succeeds_with_non_utf8_note_in_vault(self, vault, update_links):
+        (vault / "legacy.md").write_bytes(b"\xff\xfe")
+
+        result = move_note("B.md", "Beta.md", update_links=update_links)
+
+        assert result.success
+        assert (vault / "Beta.md").exists()
+        assert not (vault / "B.md").exists()
 
     def test_warns_when_links_left_stale(self, vault):
         """Issue #11: default move surfaces unresolved references count."""


### PR DESCRIPTION
## Summary
- re-read each note immediately before bulk replacement to avoid clobbering concurrent edits
- report when preview/apply replacement results are truncated by the file limit
- report a successful note move with partial link-update failure instead of claiming the move failed
- remove the bootstrap prompt's unsolicited commit/push instruction
- align public tool signatures/resources with live FastMCP schemas and add a contract test

## Validation
- 437 passed, 4 skipped; coverage 59.42%
- Ruff, Pyright, Pylint 10.00/10, Bandit, pip-audit, pre-commit
- temporary test vaults only; no real vault or provider access

## Review context
This is the first minimal implementation slice from the independent Opus residual-debt audit. A separate Sonnet review is scheduled after its session quota resets.
