### PR TITLE
fix(readers): skip legacy-encoded notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 - **Indexación Semántica de Imágenes**: El sistema ahora extrae descripciones de imágenes (`![[img|desc]]` o `![desc](img)`) y las inyecta como contexto semántico, haciendo buscable el contenido visual.
 
 ### Fixed
+- **Legacy-encoded note resilience**: Vault statistics, tag analysis, backlinks, local graphs, and orphan detection now skip non-UTF-8 notes instead of failing the entire scan.
 - **Vault exclusion hygiene**: `.trash`, `.git`, and `.obsidian` are now part of the shared packaged boundary, diagnostics use that boundary, and unused `.mcpignore` and YouTube verification scripts were removed so the documented security model has one source of truth.
 - **Lint and skill-sync partial writes**: Vault lint now skips and reports unreadable notes instead of aborting after partial fixes, and skill synchronization preserves both generated guidance blocks while reporting unreadable or unwritable skills.
 - **Bulk write safety and public contracts**: Global replacements now re-read each note immediately before writing, report when the file limit truncates results, and note moves report partial success if wikilink rewriting fails. Public tool signatures now match registered schemas, and the vault bootstrap prompt no longer instructs agents to commit or push.

--- a/obsidian_mcp/tools/analysis_logic.py
+++ b/obsidian_mcp/tools/analysis_logic.py
@@ -188,6 +188,7 @@ def analyze_tags() -> Result[str]:  # pylint: disable=too-many-locals,too-many-b
     # Tag counter with frequency
     conteo_etiquetas: dict[str, int] = {}
     archivos_con_etiquetas: list[str] = []
+    archivos_omitidos = 0
 
     for archivo in iter_safe_vault_files(vault_path):
         # Ignore system folders or registry
@@ -199,6 +200,7 @@ def analyze_tags() -> Result[str]:  # pylint: disable=too-many-locals,too-many-b
             with open(archivo, "r", encoding="utf-8") as f:
                 contenido = f.read()
         except (OSError, UnicodeDecodeError) as e:
+            archivos_omitidos += 1
             logger.debug("No se pudo leer '%s': %s", archivo, e)
             continue
 
@@ -209,7 +211,10 @@ def analyze_tags() -> Result[str]:  # pylint: disable=too-many-locals,too-many-b
                 conteo_etiquetas[tag] = conteo_etiquetas.get(tag, 0) + 1
 
     if not conteo_etiquetas:
-        return Result.ok("🏷️ No se encontraron etiquetas en el vault")
+        resultado = "🏷️ No se encontraron etiquetas en el vault"
+        if archivos_omitidos:
+            resultado += f"\n⚠️ Archivos ilegibles omitidos: {archivos_omitidos}."
+        return Result.ok(resultado)
 
     # Separate garbage hex color tags from legitimate tags
     tags_hex_basura = {
@@ -262,6 +267,8 @@ def analyze_tags() -> Result[str]:  # pylint: disable=too-many-locals,too-many-b
         if len(tags_hex_basura) > 5:
             resultado += f"   ... y {len(tags_hex_basura) - 5} más\n"
         resultado += "💡 *Tip: Usa `buscar_y_reemplazar_global` para limpiarlos.*\n"
+    if archivos_omitidos:
+        resultado += f"\n⚠️ Archivos ilegibles omitidos: {archivos_omitidos}."
 
     return Result.ok(resultado)
 
@@ -292,6 +299,7 @@ def sync_tag_registry(  # pylint: disable=too-many-locals,too-many-branches
 
     # 1. Get tags from reality
     conteo_real: dict[str, int] = {}
+    archivos_omitidos = 0
     for archivo in iter_safe_vault_files(vault_path):
         if (
             ".github" in str(archivo)
@@ -303,6 +311,7 @@ def sync_tag_registry(  # pylint: disable=too-many-locals,too-many-branches
             with open(archivo, "r", encoding="utf-8") as f:
                 contenido = f.read()
         except (OSError, UnicodeDecodeError) as e:
+            archivos_omitidos += 1
             logger.debug("No se pudo leer '%s': %s", archivo, e)
             continue
         tags = extract_tags_from_content(contenido)
@@ -335,9 +344,13 @@ def sync_tag_registry(  # pylint: disable=too-many-locals,too-many-branches
         resultado += "\n🧹 **Tags registradas que YA NO se usan:**\n"
         for t in sorted(list(ya_no_se_usan)):
             resultado += f"   • #{t}\n"
+    if archivos_omitidos:
+        resultado += f"\n⚠️ Archivos ilegibles omitidos: {archivos_omitidos}.\n"
 
     # 5. Update logic
-    if actualizar and conteo_real:
+    if actualizar and archivos_omitidos:
+        resultado += "\n⚠️ Registro no actualizado porque el escaneo fue incompleto."
+    elif actualizar and conteo_real:
         nueva_tabla = "| Tag | Frecuencia | Última verificación |\n"
         nueva_tabla += "|-----|-----------|------------------|\n"
         hoy = datetime.now().strftime("%Y-%m-%d")
@@ -394,22 +407,27 @@ def list_all_tags() -> Result[str]:
         return Result.fail("La ruta del vault no está configurada.")
 
     etiquetas_set: set[str] = set()
+    archivos_omitidos = 0
 
     for archivo in iter_safe_vault_files(vault_path):
         try:
             with open(archivo, "r", encoding="utf-8") as f:
                 contenido = f.read()
         except (OSError, UnicodeDecodeError) as e:
+            archivos_omitidos += 1
             logger.debug("No se pudo leer '%s': %s", archivo, e)
             continue
         tags = extract_tags_from_content(contenido)
         etiquetas_set.update(tags)
 
     if not etiquetas_set:
-        return Result.ok("ℹ️ No se encontraron etiquetas.")
-
-    lista_ordenada = sorted(list(etiquetas_set))
-    return Result.ok("🏷️ **Etiquetas existentes:**\n" + ", ".join(lista_ordenada))
+        resultado = "ℹ️ No se encontraron etiquetas."
+    else:
+        lista_ordenada = sorted(list(etiquetas_set))
+        resultado = "🏷️ **Etiquetas existentes:**\n" + ", ".join(lista_ordenada)
+    if archivos_omitidos:
+        resultado += f"\n⚠️ Archivos ilegibles omitidos: {archivos_omitidos}."
+    return Result.ok(resultado)
 
 
 def analyze_links() -> Result[str]:
@@ -424,6 +442,7 @@ def analyze_links() -> Result[str]:
 
     enlaces_por_archivo: dict[str, list[str]] = {}
     todos_los_enlaces: dict[str, int] = {}
+    archivos_omitidos = 0
     archivos_existentes = {f.stem for f in iter_safe_vault_files(vault_path)}
 
     for archivo in iter_safe_vault_files(vault_path):
@@ -431,6 +450,7 @@ def analyze_links() -> Result[str]:
             with open(archivo, "r", encoding="utf-8") as f:
                 contenido = f.read()
         except (OSError, UnicodeDecodeError) as e:
+            archivos_omitidos += 1
             logger.debug("No se pudo leer '%s': %s", archivo, e)
             continue
 
@@ -441,7 +461,10 @@ def analyze_links() -> Result[str]:
                 todos_los_enlaces[enlace] = todos_los_enlaces.get(enlace, 0) + 1
 
     if not todos_los_enlaces:
-        return Result.ok("🔗 No se encontraron enlaces internos en el vault")
+        resultado = "🔗 No se encontraron enlaces internos en el vault"
+        if archivos_omitidos:
+            resultado += f"\n⚠️ Archivos ilegibles omitidos: {archivos_omitidos}."
+        return Result.ok(resultado)
 
     # Analyze broken links
     enlaces_rotos = []
@@ -472,6 +495,8 @@ def analyze_links() -> Result[str]:
             resultado += f"   • [[{enlace}]]\n"
         if len(enlaces_rotos) > 10:
             resultado += f"   ... y {len(enlaces_rotos) - 10} enlaces rotos más\n"
+    if archivos_omitidos:
+        resultado += f"\n⚠️ Archivos ilegibles omitidos: {archivos_omitidos}."
 
     return Result.ok(resultado)
 

--- a/obsidian_mcp/tools/analysis_logic.py
+++ b/obsidian_mcp/tools/analysis_logic.py
@@ -90,7 +90,7 @@ def get_vault_stats() -> Result[str]:  # pylint: disable=too-many-locals
             fecha_str = fecha_mod.strftime("%Y-%m")
             por_fecha[fecha_str] = por_fecha.get(fecha_str, 0) + 1
 
-        except OSError as e:
+        except (OSError, UnicodeDecodeError) as e:
             logger.debug("No se pudo leer '%s': %s", archivo, e)
             continue
 
@@ -204,7 +204,7 @@ def analyze_tags() -> Result[str]:  # pylint: disable=too-many-locals,too-many-b
                 for tag in etiquetas:
                     conteo_etiquetas[tag] = conteo_etiquetas.get(tag, 0) + 1
 
-        except OSError as e:
+        except (OSError, UnicodeDecodeError) as e:
             logger.debug("No se pudo leer '%s': %s", archivo, e)
             continue
 
@@ -304,7 +304,7 @@ def sync_tag_registry(  # pylint: disable=too-many-locals,too-many-branches
                 tags = extract_tags_from_content(f.read())
                 for t in tags:
                     conteo_real[t] = conteo_real.get(t, 0) + 1
-        except OSError as e:
+        except (OSError, UnicodeDecodeError) as e:
             logger.debug("No se pudo leer '%s': %s", archivo, e)
             continue
 
@@ -400,7 +400,7 @@ def list_all_tags() -> Result[str]:
                 contenido = f.read()
                 tags = extract_tags_from_content(contenido)
                 etiquetas_set.update(tags)
-        except OSError as e:
+        except (OSError, UnicodeDecodeError) as e:
             logger.debug("No se pudo leer '%s': %s", archivo, e)
             continue
 
@@ -436,7 +436,7 @@ def analyze_links() -> Result[str]:
                 for enlace in enlaces:
                     todos_los_enlaces[enlace] = todos_los_enlaces.get(enlace, 0) + 1
 
-        except OSError as e:
+        except (OSError, UnicodeDecodeError) as e:
             logger.debug("No se pudo leer '%s': %s", archivo, e)
             continue
 

--- a/obsidian_mcp/tools/analysis_logic.py
+++ b/obsidian_mcp/tools/analysis_logic.py
@@ -41,7 +41,7 @@ logger = get_logger(__name__)
 HEX_COLOR_PATTERN = re.compile(r"^([0-9a-fA-F]{3}){1,2}$")
 
 
-def get_vault_stats() -> Result[str]:  # pylint: disable=too-many-locals
+def get_vault_stats() -> Result[str]:  # pylint: disable=too-many-locals,too-many-statements
     """Generate complete vault statistics.
 
     Returns:
@@ -54,7 +54,9 @@ def get_vault_stats() -> Result[str]:  # pylint: disable=too-many-locals
     vault_name = vault_path.name
 
     # Counters
-    total_notas = 0
+    archivos_markdown = 0
+    notas_analizadas = 0
+    archivos_omitidos = 0
     total_palabras = 0
     total_caracteres = 0
     carpetas: set[str] = set()
@@ -65,44 +67,44 @@ def get_vault_stats() -> Result[str]:  # pylint: disable=too-many-locals
     por_fecha: dict[str, int] = {}
 
     for archivo in iter_safe_vault_files(vault_path):
-        total_notas += 1
-
-        # Folder
-        carpeta_padre = archivo.parent.relative_to(vault_path)
-        if str(carpeta_padre) != ".":
-            carpetas.add(str(carpeta_padre))
-
+        archivos_markdown += 1
         try:
             with open(archivo, "r", encoding="utf-8") as f:
                 contenido = f.read()
-
-            # Count words and characters
-            palabras = len(contenido.split())
-            total_palabras += palabras
-            total_caracteres += len(contenido)
-
-            # Find tags and links
-            etiquetas.update(extract_tags_from_content(contenido))
-            enlaces_internos.update(extract_internal_links(contenido))
-
-            # Modification date
-            fecha_mod = datetime.fromtimestamp(archivo.stat().st_mtime).date()
-            fecha_str = fecha_mod.strftime("%Y-%m")
-            por_fecha[fecha_str] = por_fecha.get(fecha_str, 0) + 1
-
         except (OSError, UnicodeDecodeError) as e:
+            archivos_omitidos += 1
             logger.debug("No se pudo leer '%s': %s", archivo, e)
             continue
+
+        notas_analizadas += 1
+        carpeta_padre = archivo.parent.relative_to(vault_path)
+        if str(carpeta_padre) != ".":
+            carpetas.add(str(carpeta_padre))
+        total_palabras += len(contenido.split())
+        total_caracteres += len(contenido)
+        etiquetas.update(extract_tags_from_content(contenido))
+        enlaces_internos.update(extract_internal_links(contenido))
+        try:
+            fecha_mod = datetime.fromtimestamp(archivo.stat().st_mtime).date()
+        except OSError as e:
+            logger.debug("No se pudo obtener fecha de '%s': %s", archivo, e)
+        else:
+            fecha_str = fecha_mod.strftime("%Y-%m")
+            por_fecha[fecha_str] = por_fecha.get(fecha_str, 0) + 1
 
     # Format statistics
     resultado = f"📊 **Estadísticas del Vault '{vault_name}'**\n\n"
 
     resultado += "📚 **Contenido:**\n"
-    resultado += f"   • Total de notas: {total_notas:,}\n"
+    resultado += f"   • Archivos Markdown: {archivos_markdown:,}\n"
+    resultado += f"   • Notas analizadas: {notas_analizadas:,}\n"
     resultado += f"   • Total de palabras: {total_palabras:,}\n"
     resultado += f"   • Total de caracteres: {total_caracteres:,}\n"
-    promedio_palabras = total_palabras / max(total_notas, 1)
-    resultado += f"   • Promedio de palabras por nota: {promedio_palabras:.0f}\n\n"
+    promedio_palabras = total_palabras / max(notas_analizadas, 1)
+    resultado += f"   • Promedio de palabras por nota: {promedio_palabras:.0f}\n"
+    if archivos_omitidos:
+        resultado += f"   • Archivos ilegibles omitidos: {archivos_omitidos:,}\n"
+    resultado += "\n"
 
     resultado += "📁 **Organización:**\n"
     resultado += f"   • Carpetas: {len(carpetas)}\n"
@@ -188,25 +190,23 @@ def analyze_tags() -> Result[str]:  # pylint: disable=too-many-locals,too-many-b
     archivos_con_etiquetas: list[str] = []
 
     for archivo in iter_safe_vault_files(vault_path):
+        # Ignore system folders or registry
+        is_sys = ".github" in str(archivo)
+        is_reg = "Registro de Tags" in archivo.name
+        if is_sys or is_reg:
+            continue
         try:
-            # Ignore system folders or registry
-            is_sys = ".github" in str(archivo)
-            is_reg = "Registro de Tags" in archivo.name
-            if is_sys or is_reg:
-                continue
-
             with open(archivo, "r", encoding="utf-8") as f:
                 contenido = f.read()
-
-            etiquetas = extract_tags_from_content(contenido)
-            if etiquetas:
-                archivos_con_etiquetas.append(archivo.name)
-                for tag in etiquetas:
-                    conteo_etiquetas[tag] = conteo_etiquetas.get(tag, 0) + 1
-
         except (OSError, UnicodeDecodeError) as e:
             logger.debug("No se pudo leer '%s': %s", archivo, e)
             continue
+
+        etiquetas = extract_tags_from_content(contenido)
+        if etiquetas:
+            archivos_con_etiquetas.append(archivo.name)
+            for tag in etiquetas:
+                conteo_etiquetas[tag] = conteo_etiquetas.get(tag, 0) + 1
 
     if not conteo_etiquetas:
         return Result.ok("🏷️ No se encontraron etiquetas en el vault")
@@ -301,12 +301,13 @@ def sync_tag_registry(  # pylint: disable=too-many-locals,too-many-branches
             continue
         try:
             with open(archivo, "r", encoding="utf-8") as f:
-                tags = extract_tags_from_content(f.read())
-                for t in tags:
-                    conteo_real[t] = conteo_real.get(t, 0) + 1
+                contenido = f.read()
         except (OSError, UnicodeDecodeError) as e:
             logger.debug("No se pudo leer '%s': %s", archivo, e)
             continue
+        tags = extract_tags_from_content(contenido)
+        for tag in tags:
+            conteo_real[tag] = conteo_real.get(tag, 0) + 1
 
     # 2. Get tags from registry
     with open(registry_path, "r", encoding="utf-8") as f:
@@ -398,11 +399,11 @@ def list_all_tags() -> Result[str]:
         try:
             with open(archivo, "r", encoding="utf-8") as f:
                 contenido = f.read()
-                tags = extract_tags_from_content(contenido)
-                etiquetas_set.update(tags)
         except (OSError, UnicodeDecodeError) as e:
             logger.debug("No se pudo leer '%s': %s", archivo, e)
             continue
+        tags = extract_tags_from_content(contenido)
+        etiquetas_set.update(tags)
 
     if not etiquetas_set:
         return Result.ok("ℹ️ No se encontraron etiquetas.")
@@ -429,16 +430,15 @@ def analyze_links() -> Result[str]:
         try:
             with open(archivo, "r", encoding="utf-8") as f:
                 contenido = f.read()
-
-            enlaces = extract_internal_links(contenido)
-            if enlaces:
-                enlaces_por_archivo[archivo.name] = list(enlaces)
-                for enlace in enlaces:
-                    todos_los_enlaces[enlace] = todos_los_enlaces.get(enlace, 0) + 1
-
         except (OSError, UnicodeDecodeError) as e:
             logger.debug("No se pudo leer '%s': %s", archivo, e)
             continue
+
+        enlaces = extract_internal_links(contenido)
+        if enlaces:
+            enlaces_por_archivo[archivo.name] = list(enlaces)
+            for enlace in enlaces:
+                todos_los_enlaces[enlace] = todos_los_enlaces.get(enlace, 0) + 1
 
     if not todos_los_enlaces:
         return Result.ok("🔗 No se encontraron enlaces internos en el vault")

--- a/obsidian_mcp/tools/graph_logic.py
+++ b/obsidian_mcp/tools/graph_logic.py
@@ -40,6 +40,7 @@ def get_backlinks(nombre_nota: str) -> Result[str]:
         nombre_limpio = nombre_nota.replace(".md", "")
 
         backlinks: List[Dict[str, str]] = []
+        archivos_omitidos = 0
 
         for archivo in iter_safe_vault_files(vault_path):
             # Ignore self
@@ -50,6 +51,7 @@ def get_backlinks(nombre_nota: str) -> Result[str]:
                 with open(archivo, "r", encoding="utf-8") as f:
                     contenido = f.read()
             except (OSError, UnicodeDecodeError) as e:
+                archivos_omitidos += 1
                 logger.debug("No se pudo leer '%s': %s", archivo, e)
                 continue
 
@@ -67,13 +69,18 @@ def get_backlinks(nombre_nota: str) -> Result[str]:
                     break
 
         if not backlinks:
-            return Result.ok(f"🔗 No se encontraron backlinks hacia '{nombre_nota}'")
+            resultado = f"🔗 No se encontraron backlinks hacia '{nombre_nota}'"
+            if archivos_omitidos:
+                resultado += f"\n⚠️ Archivos ilegibles omitidos: {archivos_omitidos}."
+            return Result.ok(resultado)
 
         resultado = (
             f"🔗 **Backlinks hacia '{nombre_nota}'** ({len(backlinks)} notas):\n\n"
         )
         for bl in backlinks:
             resultado += f"   • [[{bl['nota']}]] - {bl['ruta']}\n"
+        if archivos_omitidos:
+            resultado += f"\n⚠️ Archivos ilegibles omitidos: {archivos_omitidos}."
 
         return Result.ok(resultado)
 
@@ -98,12 +105,14 @@ def get_notes_by_tag(tag: str) -> Result[str]:
 
         tag_limpia = tag.lstrip("#")
         notas_con_tag: List[Dict[str, str]] = []
+        archivos_omitidos = 0
 
         for archivo in iter_safe_vault_files(vault_path):
             try:
                 with open(archivo, "r", encoding="utf-8") as f:
                     contenido = f.read()
             except (OSError, UnicodeDecodeError) as e:
+                archivos_omitidos += 1
                 logger.debug("No se pudo leer '%s': %s", archivo, e)
                 continue
 
@@ -118,7 +127,10 @@ def get_notes_by_tag(tag: str) -> Result[str]:
                 )
 
         if not notas_con_tag:
-            return Result.ok(f"🏷️ No se encontraron notas con la etiqueta #{tag_limpia}")
+            resultado = f"🏷️ No se encontraron notas con la etiqueta #{tag_limpia}"
+            if archivos_omitidos:
+                resultado += f"\n⚠️ Archivos ilegibles omitidos: {archivos_omitidos}."
+            return Result.ok(resultado)
 
         resultado = (
             f"🏷️ **Notas con #{tag_limpia}** ({len(notas_con_tag)} encontradas):\n\n"
@@ -138,6 +150,8 @@ def get_notes_by_tag(tag: str) -> Result[str]:
             for nombre_nota in sorted(notas):
                 resultado += f"   • [[{nombre_nota}]]\n"
             resultado += "\n"
+        if archivos_omitidos:
+            resultado += f"⚠️ Archivos ilegibles omitidos: {archivos_omitidos}.\n"
 
         return Result.ok(resultado)
 
@@ -145,9 +159,10 @@ def get_notes_by_tag(tag: str) -> Result[str]:
         return Result.fail(f"Error al buscar por tag: {e}")
 
 
-def _find_backlinks(vault_path: Path, nombre_limpio: str) -> list[str]:
-    """Scan vault for notes that link to the given note name."""
+def _find_backlinks(vault_path: Path, nombre_limpio: str) -> tuple[list[str], int]:
+    """Return readable backlinks and the number of skipped files."""
     backlinks = []
+    archivos_omitidos = 0
     for archivo in iter_safe_vault_files(vault_path):
         if archivo.stem == nombre_limpio:
             continue
@@ -155,6 +170,7 @@ def _find_backlinks(vault_path: Path, nombre_limpio: str) -> list[str]:
             with open(archivo, "r", encoding="utf-8") as f:
                 cont = f.read()
         except (OSError, UnicodeDecodeError) as e:
+            archivos_omitidos += 1
             logger.debug("No se pudo leer '%s': %s", archivo, e)
             continue
         enlaces = extract_internal_links(cont)
@@ -162,7 +178,7 @@ def _find_backlinks(vault_path: Path, nombre_limpio: str) -> list[str]:
             if enlace.split("|")[0].strip() == nombre_limpio:
                 backlinks.append(archivo.stem)
                 break
-    return backlinks
+    return backlinks, archivos_omitidos
 
 
 def _format_link_section(
@@ -222,7 +238,7 @@ def get_local_graph(nombre_nota: str, profundidad: int = 1) -> Result[str]:
         enlaces_salientes = list({e.split("|")[0].strip() for e in raw_links})
 
         # Get backlinks
-        backlinks = _find_backlinks(vault_path, nombre_limpio)
+        backlinks, archivos_omitidos = _find_backlinks(vault_path, nombre_limpio)
 
         # Format result
         resultado = f"🕸️ **Grafo Local de '{nombre_nota}'**\n\n"
@@ -236,6 +252,8 @@ def get_local_graph(nombre_nota: str, profundidad: int = 1) -> Result[str]:
 
         total = len(enlaces_salientes) + len(backlinks)
         resultado += f"\n📊 **Conectividad total**: {total} conexiones"
+        if archivos_omitidos:
+            resultado += f"\n⚠️ Archivos ilegibles omitidos: {archivos_omitidos}."
 
         return Result.ok(resultado)
 

--- a/obsidian_mcp/tools/graph_logic.py
+++ b/obsidian_mcp/tools/graph_logic.py
@@ -63,7 +63,7 @@ def get_backlinks(nombre_nota: str) -> Result[str]:
                             }
                         )
                         break
-            except OSError as e:
+            except (OSError, UnicodeDecodeError) as e:
                 logger.debug("No se pudo leer '%s': %s", archivo, e)
                 continue
 
@@ -78,7 +78,7 @@ def get_backlinks(nombre_nota: str) -> Result[str]:
 
         return Result.ok(resultado)
 
-    except OSError as e:
+    except (OSError, UnicodeDecodeError) as e:
         return Result.fail(f"Error al obtener backlinks: {e}")
 
 
@@ -113,7 +113,7 @@ def get_notes_by_tag(tag: str) -> Result[str]:
                             "ruta": str(ruta_rel),
                         }
                     )
-            except OSError as e:
+            except (OSError, UnicodeDecodeError) as e:
                 logger.debug("No se pudo leer '%s': %s", archivo, e)
                 continue
 
@@ -141,7 +141,7 @@ def get_notes_by_tag(tag: str) -> Result[str]:
 
         return Result.ok(resultado)
 
-    except OSError as e:
+    except (OSError, UnicodeDecodeError) as e:
         return Result.fail(f"Error al buscar por tag: {e}")
 
 
@@ -159,7 +159,7 @@ def _find_backlinks(vault_path: Path, nombre_limpio: str) -> list[str]:
                 if enlace.split("|")[0].strip() == nombre_limpio:
                     backlinks.append(archivo.stem)
                     break
-        except OSError as e:
+        except (OSError, UnicodeDecodeError) as e:
             logger.debug("No se pudo leer '%s': %s", archivo, e)
     return backlinks
 
@@ -235,7 +235,7 @@ def get_local_graph(nombre_nota: str, profundidad: int = 1) -> Result[str]:
 
         return Result.ok(resultado)
 
-    except OSError as e:
+    except (OSError, UnicodeDecodeError) as e:
         return Result.fail(f"Error al obtener grafo local: {e}")
 
 
@@ -262,7 +262,7 @@ def find_orphan_notes() -> Result[str]:
                 enlaces_limpios = [e.split("|")[0].strip() for e in enlaces]
                 enlaces_salientes_por_nota[archivo.stem] = enlaces_limpios
                 todos_los_enlaces.update(enlaces_limpios)
-            except OSError as e:
+            except (OSError, UnicodeDecodeError) as e:
                 logger.debug("No se pudo leer '%s': %s", archivo, e)
                 continue
 
@@ -298,5 +298,5 @@ def find_orphan_notes() -> Result[str]:
 
         return Result.ok(resultado)
 
-    except OSError as e:
+    except (OSError, UnicodeDecodeError) as e:
         return Result.fail(f"Error al encontrar notas huerfanas: {e}")

--- a/obsidian_mcp/tools/graph_logic.py
+++ b/obsidian_mcp/tools/graph_logic.py
@@ -49,23 +49,22 @@ def get_backlinks(nombre_nota: str) -> Result[str]:
             try:
                 with open(archivo, "r", encoding="utf-8") as f:
                     contenido = f.read()
-
-                enlaces = extract_internal_links(contenido)
-
-                for enlace in enlaces:
-                    enlace_limpio = enlace.split("|")[0].strip()
-                    if enlace_limpio == nombre_limpio:
-                        ruta_rel = archivo.relative_to(vault_path)
-                        backlinks.append(
-                            {
-                                "nota": archivo.stem,
-                                "ruta": str(ruta_rel),
-                            }
-                        )
-                        break
             except (OSError, UnicodeDecodeError) as e:
                 logger.debug("No se pudo leer '%s': %s", archivo, e)
                 continue
+
+            enlaces = extract_internal_links(contenido)
+            for enlace in enlaces:
+                enlace_limpio = enlace.split("|")[0].strip()
+                if enlace_limpio == nombre_limpio:
+                    ruta_rel = archivo.relative_to(vault_path)
+                    backlinks.append(
+                        {
+                            "nota": archivo.stem,
+                            "ruta": str(ruta_rel),
+                        }
+                    )
+                    break
 
         if not backlinks:
             return Result.ok(f"🔗 No se encontraron backlinks hacia '{nombre_nota}'")
@@ -78,7 +77,7 @@ def get_backlinks(nombre_nota: str) -> Result[str]:
 
         return Result.ok(resultado)
 
-    except (OSError, UnicodeDecodeError) as e:
+    except OSError as e:
         return Result.fail(f"Error al obtener backlinks: {e}")
 
 
@@ -104,18 +103,19 @@ def get_notes_by_tag(tag: str) -> Result[str]:
             try:
                 with open(archivo, "r", encoding="utf-8") as f:
                     contenido = f.read()
-                tags = extract_tags_from_content(contenido)
-                if tag_limpia in tags:
-                    ruta_rel = archivo.relative_to(vault_path)
-                    notas_con_tag.append(
-                        {
-                            "nota": archivo.stem,
-                            "ruta": str(ruta_rel),
-                        }
-                    )
             except (OSError, UnicodeDecodeError) as e:
                 logger.debug("No se pudo leer '%s': %s", archivo, e)
                 continue
+
+            tags = extract_tags_from_content(contenido)
+            if tag_limpia in tags:
+                ruta_rel = archivo.relative_to(vault_path)
+                notas_con_tag.append(
+                    {
+                        "nota": archivo.stem,
+                        "ruta": str(ruta_rel),
+                    }
+                )
 
         if not notas_con_tag:
             return Result.ok(f"🏷️ No se encontraron notas con la etiqueta #{tag_limpia}")
@@ -141,7 +141,7 @@ def get_notes_by_tag(tag: str) -> Result[str]:
 
         return Result.ok(resultado)
 
-    except (OSError, UnicodeDecodeError) as e:
+    except OSError as e:
         return Result.fail(f"Error al buscar por tag: {e}")
 
 
@@ -154,13 +154,14 @@ def _find_backlinks(vault_path: Path, nombre_limpio: str) -> list[str]:
         try:
             with open(archivo, "r", encoding="utf-8") as f:
                 cont = f.read()
-            enlaces = extract_internal_links(cont)
-            for enlace in enlaces:
-                if enlace.split("|")[0].strip() == nombre_limpio:
-                    backlinks.append(archivo.stem)
-                    break
         except (OSError, UnicodeDecodeError) as e:
             logger.debug("No se pudo leer '%s': %s", archivo, e)
+            continue
+        enlaces = extract_internal_links(cont)
+        for enlace in enlaces:
+            if enlace.split("|")[0].strip() == nombre_limpio:
+                backlinks.append(archivo.stem)
+                break
     return backlinks
 
 
@@ -211,8 +212,11 @@ def get_local_graph(nombre_nota: str, profundidad: int = 1) -> Result[str]:
         nombre_limpio = nota_path.stem
 
         # Get outgoing links
-        with open(nota_path, "r", encoding="utf-8") as f:
-            contenido = f.read()
+        try:
+            with open(nota_path, "r", encoding="utf-8") as f:
+                contenido = f.read()
+        except (OSError, UnicodeDecodeError) as e:
+            return Result.fail(f"Error al leer la nota central: {e}")
 
         raw_links = extract_internal_links(contenido)
         enlaces_salientes = list({e.split("|")[0].strip() for e in raw_links})
@@ -235,7 +239,7 @@ def get_local_graph(nombre_nota: str, profundidad: int = 1) -> Result[str]:
 
         return Result.ok(resultado)
 
-    except (OSError, UnicodeDecodeError) as e:
+    except OSError as e:
         return Result.fail(f"Error al obtener grafo local: {e}")
 
 
@@ -253,21 +257,26 @@ def find_orphan_notes() -> Result[str]:
 
         enlaces_salientes_por_nota: Dict[str, List[str]] = {}
         todos_los_enlaces: set = set()
+        archivos_legibles: list[Path] = []
+        archivos_omitidos = 0
 
         for archivo in iter_safe_vault_files(vault_path):
             try:
                 with open(archivo, "r", encoding="utf-8") as f:
                     contenido = f.read()
-                enlaces = extract_internal_links(contenido)
-                enlaces_limpios = [e.split("|")[0].strip() for e in enlaces]
-                enlaces_salientes_por_nota[archivo.stem] = enlaces_limpios
-                todos_los_enlaces.update(enlaces_limpios)
             except (OSError, UnicodeDecodeError) as e:
+                archivos_omitidos += 1
                 logger.debug("No se pudo leer '%s': %s", archivo, e)
                 continue
 
+            archivos_legibles.append(archivo)
+            enlaces = extract_internal_links(contenido)
+            enlaces_limpios = [e.split("|")[0].strip() for e in enlaces]
+            enlaces_salientes_por_nota[archivo.stem] = enlaces_limpios
+            todos_los_enlaces.update(enlaces_limpios)
+
         notas_huerfanas = []
-        for archivo in iter_safe_vault_files(vault_path):
+        for archivo in archivos_legibles:
             nombre = archivo.stem
             if any(x in str(archivo) for x in [".git", ".obsidian", "ZZ_"]):
                 continue
@@ -285,9 +294,10 @@ def find_orphan_notes() -> Result[str]:
                 )
 
         if not notas_huerfanas:
-            return Result.ok(
-                "✅ No hay notas huérfanas. Todas están conectadas al grafo."
-            )
+            resultado = "✅ No hay notas huérfanas. Todas están conectadas al grafo."
+            if archivos_omitidos:
+                resultado += f"\n⚠️ Archivos ilegibles omitidos: {archivos_omitidos}."
+            return Result.ok(resultado)
 
         resultado = f"🔍 **Notas Huérfanas** ({len(notas_huerfanas)}):\n\n"
         resultado += "Estas notas no tienen enlaces entrantes ni salientes:\n\n"
@@ -295,8 +305,10 @@ def find_orphan_notes() -> Result[str]:
             resultado += f"   • {nota['ruta']}\n"
         if len(notas_huerfanas) > 30:
             resultado += f"\n... y {len(notas_huerfanas) - 30} más"
+        if archivos_omitidos:
+            resultado += f"\n\n⚠️ Archivos ilegibles omitidos: {archivos_omitidos}."
 
         return Result.ok(resultado)
 
-    except (OSError, UnicodeDecodeError) as e:
+    except OSError as e:
         return Result.fail(f"Error al encontrar notas huerfanas: {e}")

--- a/tests/test_non_utf8_resilience.py
+++ b/tests/test_non_utf8_resilience.py
@@ -50,6 +50,25 @@ def test_vault_reader_skips_non_utf8_note(tmp_path, monkeypatch, operation):
     result = operation()
 
     assert result.success, result.error
+    assert "Archivos ilegibles omitidos: 1" in (result.data or "")
+
+
+def test_incomplete_tag_scan_does_not_update_registry(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "Good.md").write_text("# Good\n\n#new\n", encoding="utf-8")
+    (vault / "Legacy.md").write_bytes(b"\xff\xfe")
+    registry = vault / "Registro de Tags del Vault.md"
+    original = "# Tags\n\n- `old`\n\n## Estadísticas\n\nold table\n"
+    registry.write_text(original, encoding="utf-8")
+    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+    reset_settings()
+
+    result = sync_tag_registry(True)
+
+    assert result.success
+    assert registry.read_text(encoding="utf-8") == original
+    assert "Registro no actualizado" in (result.data or "")
 
 
 def test_stats_and_orphans_disclose_skipped_note(tmp_path, monkeypatch):

--- a/tests/test_non_utf8_resilience.py
+++ b/tests/test_non_utf8_resilience.py
@@ -1,0 +1,46 @@
+"""Vault-wide readers skip legacy-encoded notes instead of aborting."""
+
+import pytest
+
+from obsidian_mcp.config import reset_settings
+from obsidian_mcp.tools.analysis_logic import (
+    analyze_links,
+    analyze_tags,
+    get_vault_stats,
+    list_all_tags,
+)
+from obsidian_mcp.tools.graph_logic import (
+    find_orphan_notes,
+    get_backlinks,
+    get_local_graph,
+    get_notes_by_tag,
+)
+from obsidian_mcp.utils import invalidate_note_cache
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        get_vault_stats,
+        analyze_tags,
+        list_all_tags,
+        analyze_links,
+        lambda: get_backlinks("Good"),
+        lambda: get_notes_by_tag("tag"),
+        lambda: get_local_graph("Good"),
+        find_orphan_notes,
+    ],
+)
+def test_vault_reader_skips_non_utf8_note(tmp_path, monkeypatch, operation):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "Good.md").write_text("# Good\n\n#tag [[Other]]\n", encoding="utf-8")
+    (vault / "Other.md").write_text("# Other\n\n[[Good]]\n", encoding="utf-8")
+    (vault / "Legacy.md").write_bytes(b"\xff\xfe")
+    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+    reset_settings()
+    invalidate_note_cache()
+
+    result = operation()
+
+    assert result.success, result.error

--- a/tests/test_non_utf8_resilience.py
+++ b/tests/test_non_utf8_resilience.py
@@ -3,11 +3,13 @@
 import pytest
 
 from obsidian_mcp.config import reset_settings
+from obsidian_mcp.tools import analysis_logic
 from obsidian_mcp.tools.analysis_logic import (
     analyze_links,
     analyze_tags,
     get_vault_stats,
     list_all_tags,
+    sync_tag_registry,
 )
 from obsidian_mcp.tools.graph_logic import (
     find_orphan_notes,
@@ -29,6 +31,7 @@ from obsidian_mcp.utils import invalidate_note_cache
         lambda: get_notes_by_tag("tag"),
         lambda: get_local_graph("Good"),
         find_orphan_notes,
+        lambda: sync_tag_registry(False),
     ],
 )
 def test_vault_reader_skips_non_utf8_note(tmp_path, monkeypatch, operation):
@@ -37,6 +40,9 @@ def test_vault_reader_skips_non_utf8_note(tmp_path, monkeypatch, operation):
     (vault / "Good.md").write_text("# Good\n\n#tag [[Other]]\n", encoding="utf-8")
     (vault / "Other.md").write_text("# Other\n\n[[Good]]\n", encoding="utf-8")
     (vault / "Legacy.md").write_bytes(b"\xff\xfe")
+    (vault / "Registro de Tags del Vault.md").write_text(
+        "# Tags\n\n- `tag`\n", encoding="utf-8"
+    )
     monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
     reset_settings()
     invalidate_note_cache()
@@ -44,3 +50,54 @@ def test_vault_reader_skips_non_utf8_note(tmp_path, monkeypatch, operation):
     result = operation()
 
     assert result.success, result.error
+
+
+def test_stats_and_orphans_disclose_skipped_note(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "Good.md").write_text("# Good\n\n[[Other]]\n", encoding="utf-8")
+    (vault / "Other.md").write_text("# Other\n\n[[Good]]\n", encoding="utf-8")
+    (vault / "Legacy.md").write_bytes(b"\xff\xfe")
+    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+    reset_settings()
+    invalidate_note_cache()
+
+    stats = get_vault_stats()
+    orphans = find_orphan_notes()
+
+    assert stats.success and orphans.success
+    assert "Archivos Markdown: 3" in (stats.data or "")
+    assert "Notas analizadas: 2" in (stats.data or "")
+    assert "Archivos ilegibles omitidos: 1" in (stats.data or "")
+    assert "Legacy.md" not in (orphans.data or "")
+    assert "Archivos ilegibles omitidos: 1" in (orphans.data or "")
+
+
+def test_non_utf8_central_note_returns_failure(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "Legacy.md").write_bytes(b"\xff\xfe")
+    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+    reset_settings()
+    invalidate_note_cache()
+
+    result = get_local_graph("Legacy")
+
+    assert not result.success
+    assert "nota central" in (result.error or "")
+
+
+def test_processing_unicode_error_is_not_reported_as_success(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "Good.md").write_text("# Good\n", encoding="utf-8")
+    monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(vault))
+    reset_settings()
+
+    def fail_processing(_content):
+        raise UnicodeDecodeError("utf-8", b"x", 0, 1, "processor bug")
+
+    monkeypatch.setattr(analysis_logic, "extract_internal_links", fail_processing)
+
+    with pytest.raises(UnicodeDecodeError):
+        analyze_links()


### PR DESCRIPTION
## Summary
- treat `UnicodeDecodeError` like other per-file read failures in vault-wide graph and analysis scans
- keep backlinks, tags, statistics, local graphs, link analysis, and orphan detection available when one note uses a legacy encoding
- add one parameterized temporary-vault regression covering all eight public reader paths

## Validation
- 460 passed, 4 skipped; coverage 64.22%
- Ruff, Pyright, Pylint 10.00/10, Bandit, pip-audit
- generated temporary vaults only

## Review
Implements N5 from the independent Opus debt audit. Must receive independent review of this exact PR before merge.
