### PR TITLE
chore(deps): refresh dependency floors and lockfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ## [Unreleased]
 
+### Changed
+- **Dependencias: suelos actualizados y lockfile regenerado**: `requests` >=2.34.2, `langgraph` >=1.2.7 (extra `rag`), `types-PyYAML` >=6.0.12.20260518 y `bandit[toml]` >=1.9.4. Consolida las PR #86, #87, #88 y #89, que tocaban solo `pyproject.toml` y dejaban `uv.lock` desincronizado (`uv lock --check` fallaba); CI no lo detectaba porque `uv sync --dev` re-resuelve en silencio en vez de validar el lock.
+
 ### Added
 - Pipeline de MCPB con binario local para generar bundles instalables por plataforma sin depender del Python del usuario.
 - **AFP #51 — Reposición y borrado de grupos en canvas**: Nuevas tools `canvas.move_card(node_id, x, y)` (reposiciona cualquier nodo) y `canvas.remove_group(group_id, remove_contents=False)` (borra un grupo y, opcionalmente, las tarjetas que contiene). Antes había que editar el `.canvas` a mano.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "cryptography>=50.0.0",
     "pygments>=2.20.0",
     "pyjwt>=2.13.0",
-    "requests>=2.33.1",
+    "requests>=2.34.2",
 ]
 
 [project.optional-dependencies]
@@ -49,7 +49,7 @@ rag = [
     "langchain-chroma>=0.2.0",
     "langchain-text-splitters>=1.1.2",
     "langchain-classic>=1.0.8",
-    "langgraph>=1.2.5",
+    "langgraph>=1.2.7",
     "chromadb>=0.5.0,<1.0.0",
     "rank-bm25>=0.2.2",
 ]
@@ -71,13 +71,13 @@ dev = [
     "ruff>=0.15.20",
     "pyright>=1.1.372",
     "mypy>=1.19.1",
-    "types-PyYAML>=6.0.12.20260408",
+    "types-PyYAML>=6.0.12.20260518",
     "types-aiofiles>=25.1.0.20260409",
     "matplotlib>=3.10.8",
     "numpy>=2.4.6",
     "pre-commit>=4.0.0",
     "pylint>=4.0.5",
-    "bandit[toml]>=1.8.0",
+    "bandit[toml]>=1.9.4",
     "pip-audit>=2.10.1",
     # uv seeds the dev venv with pip; pin >=26.1.2 to clear PYSEC-2026-196
     # (the 26.1.1 seed otherwise fails the pip-audit pre-commit hook).

--- a/uv.lock
+++ b/uv.lock
@@ -2014,7 +2014,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.5"
+version = "1.2.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -2024,9 +2024,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/9d/7c9ebd17b95569122e2d2e641f535cf086c870d66bb8e59be33cdba856b3/langgraph-1.2.5.tar.gz", hash = "sha256:09a3bdec6fdb3228623fc78b6f69a1400d383f66348d0b04d0efb692022cc6ef", size = 712532, upload-time = "2026-06-12T20:30:58.498Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/1d/a32f3caf4b3d60651656c0d64976b48d168653e81c71bb7512e9a31541aa/langgraph-1.2.10.tar.gz", hash = "sha256:05a183a746ed570a06c7c1b879920163509a75df9e44e92dd2238218d677fd37", size = 723404, upload-time = "2026-07-28T18:33:51.441Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/03/187281cf61845c5a9c397ae6cd9cd73bb54b39435e5575a7b83c853e5b76/langgraph-1.2.5-py3-none-any.whl", hash = "sha256:9286bb5def82fc865959c14378fe473518dc097d586225f622f029637a2a4bb9", size = 246150, upload-time = "2026-06-12T20:30:57.018Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4d/3fc3e2535ee2c731130d71371848ebc6d4a9d2e8ae6060b11987ba134951/langgraph-1.2.10-py3-none-any.whl", hash = "sha256:52c48bd42fa31a1de0e1c0f0ebfe342e11ca2957b8b3563f83dbd60d8e30f921", size = 247753, upload-time = "2026-07-28T18:33:50.028Z" },
 ]
 
 [[package]]
@@ -2838,7 +2838,7 @@ requires-dist = [
     { name = "langchain-core", marker = "extra == 'rag'", specifier = ">=0.3.0" },
     { name = "langchain-ollama", marker = "extra == 'rag'", specifier = ">=0.2.0" },
     { name = "langchain-text-splitters", marker = "extra == 'rag'", specifier = ">=1.1.2" },
-    { name = "langgraph", marker = "extra == 'rag'", specifier = ">=1.2.5" },
+    { name = "langgraph", marker = "extra == 'rag'", specifier = ">=1.2.7" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings", specifier = ">=2.14.1" },
     { name = "pygments", specifier = ">=2.20.0" },
@@ -2846,7 +2846,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rank-bm25", marker = "extra == 'rag'", specifier = ">=0.2.2" },
-    { name = "requests", specifier = ">=2.33.1" },
+    { name = "requests", specifier = ">=2.34.2" },
     { name = "tqdm", specifier = ">=4.68.2" },
     { name = "youtube-transcript-api", specifier = ">=1.2.4" },
 ]
@@ -2855,7 +2855,7 @@ provides-extras = ["rag"]
 [package.metadata.requires-dev]
 dev = [
     { name = "anyio", specifier = ">=4.4.0" },
-    { name = "bandit", extras = ["toml"], specifier = ">=1.8.0" },
+    { name = "bandit", extras = ["toml"], specifier = ">=1.9.4" },
     { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "numpy", specifier = ">=2.4.6" },
@@ -2869,7 +2869,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.15.20" },
     { name = "types-aiofiles", specifier = ">=25.1.0.20260409" },
-    { name = "types-pyyaml", specifier = ">=6.0.12.20260408" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
 ]
 
 [[package]]
@@ -4037,7 +4037,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.33.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -4045,9 +4045,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Consolidates the four still-relevant Dependabot bumps and, unlike those PRs, regenerates `uv.lock`.

## Changes

| Dependency | Floor | Locked version |
|---|---|---|
| `requests` | `>=2.33.1` → `>=2.34.2` | 2.33.1 → 2.34.2 |
| `langgraph` (extra `rag`) | `>=1.2.5` → `>=1.2.7` | 1.2.5 → 1.2.10 |
| `types-PyYAML` (dev) | `>=6.0.12.20260408` → `>=6.0.12.20260518` | unchanged (already 6.0.12.20260518) |
| `bandit[toml]` (dev) | `>=1.8.0` → `>=1.9.4` | unchanged (already 1.9.4) |

The `uv.lock` diff is limited to those two package blocks plus the four `requires-dist` / `requires-dev` specifier lines — no collateral resolution churn.

## Why supersede #86–#89

Each of those PRs modified `pyproject.toml` only. Applying any one of them on top of current `main` makes `uv lock --check` fail (verified individually), because the lock records the declared specifiers as well as the resolution. CI does not catch this: it runs `uv sync --dev`, which silently re-resolves rather than validating the lock, so the drift would only surface as a spuriously dirty `uv.lock` in contributors' working trees.

`requests` and `langgraph` are not imported anywhere in the codebase. `requests` is a deliberate security floor over a transitive (`youtube-transcript-api`, added in 50d5fa4 "update vulnerable deps"), so bumping rather than dropping it is intentional. `langgraph` belongs to the deprecated `rag` extra and is covered by the separate RAG-stack audit.

## Validation

Local, on this branch, with a throwaway vault:

- `uv lock --check` — clean
- 465 passed, 4 skipped; coverage 64.89%
- Ruff check + format, Pyright (0 errors, 2 expected optional-RAG warnings), Pylint 10.00/10
- Bandit (0 issues), `pip-audit` (no known vulnerabilities)

Supersedes #86, #87, #88, #89.