### PR TITLE
ci: test the platforms and versions the package claims to support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: "3.11"
+  # UV_PYTHON, not a bare `uv python install`: uv resolves the interpreter from
+  # the committed .python-version (3.13) unless UV_PYTHON overrides it, so these
+  # jobs silently ran on 3.13 while claiming 3.11. The test job overrides this
+  # per matrix entry.
+  UV_PYTHON: "3.11"
 
 jobs:
   lint:
@@ -26,7 +30,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv python install ${{ env.PYTHON_VERSION }}
+        run: uv python install ${{ env.UV_PYTHON }}
 
       - name: Install dependencies
         run: uv sync --dev
@@ -49,7 +53,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv python install ${{ env.PYTHON_VERSION }}
+        run: uv python install ${{ env.UV_PYTHON }}
 
       - name: Install dependencies
         run: uv sync --dev
@@ -69,7 +73,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv python install ${{ env.PYTHON_VERSION }}
+        run: uv python install ${{ env.UV_PYTHON }}
 
       - name: Install dependencies
         run: uv sync --dev
@@ -81,10 +85,30 @@ jobs:
         run: uv run pip-audit
 
   test:
-    name: Tests
-    runs-on: ubuntu-latest
+    name: Tests (${{ matrix.os }}, py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Version axis on Linux: pyproject declares requires-python >=3.11 and
+        # advertises 3.11/3.12/3.13 classifiers, so all three get exercised.
+        os: [ubuntu-latest]
+        python-version: ["3.11", "3.12", "3.13"]
+        # Platform axis on the lowest supported version only.
+        # Windows is the one runner that executes otherwise-dead code: both
+        # platform branches in the package are Windows-only — utils/timeout.py
+        # falls back from SIGALRM to threading, and utils/vault.py skips the
+        # directory fsync in atomic writes when os.name == "nt".
+        # macOS runs the same branches as Linux; it is here because APFS is
+        # case-insensitive by default, which is a real hazard for a tool whose
+        # security boundary is path comparison.
+        include:
+          - os: macos-latest
+            python-version: "3.11"
+          - os: windows-latest
+            python-version: "3.11"
     env:
-      OBSIDIAN_VAULT_PATH: /tmp/test-vault
+      UV_PYTHON: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v7
 
@@ -94,17 +118,14 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv python install ${{ env.PYTHON_VERSION }}
+        run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: uv sync --dev
 
-      - name: Set up test environment
-        run: |
-          mkdir -p /tmp/test-vault
-          echo "# Test note" > /tmp/test-vault/test.md
-          cp .env.example .env
-          sed -i 's|OBSIDIAN_VAULT_PATH=.*|OBSIDIAN_VAULT_PATH=/tmp/test-vault|' .env
-
+      # No vault bootstrap step: the autouse `isolated_vault` fixture in
+      # tests/conftest.py points OBSIDIAN_VAULT_PATH at a tmp_path for every
+      # test, so a CI-provided vault is never read. Verified — the suite passes
+      # with the variable unset and with it set to a nonexistent path.
       - name: Run tests with coverage
-        run: uv run pytest --cov=obsidian_mcp --cov-report=term-missing --cov-fail-under=25
+        run: uv run pytest --cov=obsidian_mcp --cov-report=term-missing --cov-fail-under=60

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ make coverage         # uv run pytest --cov=obsidian_mcp --cov-report=term-missi
 make lint             # uv run ruff check . && uv run pyright .
 make format           # uv run ruff check --fix . && uv run ruff format .
 
-# Pre-commit hooks (ruff, pyright, pylint, bandit + general checks)
+# Pre-commit hooks (ruff, pyright, pylint, bandit, actionlint, pip-audit + general checks)
 make hooks            # uv run pre-commit install
 make check            # uv run pre-commit run --all-files
 
@@ -39,7 +39,9 @@ make check            # uv run pre-commit run --all-files
 - Framework: `pytest` with `anyio` for async tests (NOT asyncio)
 - Single test: `uv run pytest tests/test_basic.py::TestClassName::test_name -v`
 - Coverage: `uv run pytest tests/ --cov=obsidian_mcp`
-- CI minimum coverage: **25%**
+- CI minimum coverage: **60%** (measured total is ~65%; the gap is headroom, not
+  a claim that the optional `semantic/` RAG modules are covered — they are not)
+- CI test matrix: Python 3.11/3.12/3.13 on Linux, plus 3.11 on macOS and Windows
 - All async tests must use `anyio` fixtures, not `asyncio`
 
 ## Architecture
@@ -159,14 +161,14 @@ Installed via `make hooks`. Runs on every commit:
 
 ### CI Pipeline (GitHub Actions)
 
-4 parallel jobs on push/PR to `main`:
+Parallel jobs on push/PR to `main`:
 
-| Job | What it checks |
-|---|---|
-| **Lint & Format** | `ruff check .` + `ruff format --check .` |
-| **Type Check** | `pyright` |
-| **Security** | `bandit -c pyproject.toml -r obsidian_mcp/` |
-| **Tests** | `pytest --cov --cov-fail-under=25` |
+| Job | Runners | What it checks |
+|---|---|---|
+| **Lint & Format** | Linux / 3.11 | `ruff check .` + `ruff format --check .` |
+| **Type Check** | Linux / 3.11 | `pyright` |
+| **Security** | Linux / 3.11 | `bandit -c pyproject.toml -r obsidian_mcp/` + `pip-audit` |
+| **Tests** | 5-job matrix (see above) | `pytest --cov --cov-fail-under=60` |
 
 ### Code Style
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.h
 
 ## [Unreleased]
 
+### Changed
+- **CI: matriz de sistemas y versiones**: el job de tests pasa de un único runner a una matriz de 5 entradas — Python 3.11/3.12/3.13 en Linux, más 3.11 en macOS y Windows. Windows es el que ejecuta código hasta ahora muerto: las dos ramas de plataforma del paquete son exclusivas de Windows — el fallback de SIGALRM a threading en `utils/timeout.py` y el salto del `fsync` de directorio en las escrituras atómicas de `utils/vault.py` cuando `os.name == "nt"`. macOS recorre las mismas ramas que Linux; está por el sistema de ficheros insensible a mayúsculas de APFS, un riesgo real para una herramienta cuya frontera de seguridad es la comparación de rutas.
+- **CI: el interpréte declarado ahora es el que se usa**: los jobs fijaban `PYTHON_VERSION: "3.11"` e instalaban 3.11, pero `uv sync` resolvía el intérprete desde el `.python-version` del repo (3.13), así que el pipeline llevaba ejecutándose en 3.13 mientras decía 3.11. Sustituido por `UV_PYTHON`, que sí tiene precedencia sobre `.python-version`.
+- **CI: umbral de cobertura de 25% a 60%**: la cobertura medida es 64.89%; el margen restante es holgura para variación entre plataformas, no una afirmación de que los módulos opcionales de `semantic/` estén cubiertos — no lo están, y no se excluyen de la medición para maquillar el número.
+
+### Removed
+- **CI: paso de preparación del vault de prueba**: copiaba `.env.example` y lo reescribía con `sed -i`, incompatible con el sed de BSD en macOS. Resulta que el paso entero sobraba: el fixture autouse `isolated_vault` de `tests/conftest.py` apunta `OBSIDIAN_VAULT_PATH` a un `tmp_path` en cada test, así que el vault que preparaba CI no se leía nunca. Comprobado: la suite pasa con la variable sin definir y también apuntando a una ruta inexistente.
+
 ### Added
 - Pipeline de MCPB con binario local para generar bundles instalables por plataforma sin depender del Python del usuario.
 - **AFP #51 — Reposición y borrado de grupos en canvas**: Nuevas tools `canvas.move_card(node_id, x, y)` (reposiciona cualquier nodo) y `canvas.remove_group(group_id, remove_contents=False)` (borra un grupo y, opcionalmente, las tarjetas que contiene). Antes había que editar el `.canvas` a mano.


### PR DESCRIPTION
Closes the gap between what `pyproject.toml` advertises and what CI actually exercises, and retires the obsolete 25% coverage gate.

## The declared Python was never the one in use

The jobs set `PYTHON_VERSION: "3.11"` and ran `uv python install 3.11` — but installing an interpreter does not select it. `uv sync` resolves from the committed `.python-version`, which pins **3.13**. Verified locally:

```
$ uv sync --dev && uv run python -VV
Python 3.13.11
$ UV_PYTHON=3.11 uv sync --dev && uv run python -VV
Python 3.11.14
```

The whole pipeline has been testing 3.13 while reporting 3.11. Replaced with `UV_PYTHON`, which does take precedence over `.python-version`, overridden per matrix entry in the test job. Lint, type-check and security therefore genuinely move 3.13 → 3.11; re-ran all of them on 3.11 with no new failures.

## Version and platform matrix

The test job becomes a 5-entry matrix — 3.11/3.12/3.13 on Linux, plus 3.11 on macOS and Windows — with `fail-fast: false` so one failure doesn't hide the others.

**Windows** is the runner that earns its place on coverage grounds. Both platform branches in the package are Windows-only, and neither has ever executed:

- `obsidian_mcp/utils/timeout.py:22` — falls back from SIGALRM to threading
- `obsidian_mcp/utils/vault.py:198` — skips the atomic-write directory `fsync` when `os.name == "nt"`

**macOS** takes the same branches as Linux; it is here for a different reason — APFS is case-insensitive by default, a real hazard for a tool whose security boundary is path comparison.

Lint, type-check and security stay single-runner: platform-independent tool invocations, fanning them out would only burn minutes.

## Coverage gate: 25% → 60%

Measured total is **64.89%**, identical on 3.11, 3.12 and 3.13. The remaining margin is deliberate headroom for cross-platform variation, not an implicit claim of broader coverage. This deliberately does **not** add a `[tool.coverage] omit` for `obsidian_mcp/semantic/` — excluding the optional legacy RAG modules would inflate the percentage while covering nothing, exactly the kind of flattering-but-false number the recent hardening work has been removing.

## The test-vault step is deleted, not ported

The old step did `cp .env.example .env` then rewrote it with `sed -i` — which BSD sed on macOS would have rejected. But the whole step was dead weight: the autouse `isolated_vault` fixture in `tests/conftest.py:14` repoints `OBSIDIAN_VAULT_PATH` at a `tmp_path` for every test, so the vault CI built was never read. Verified:

```
no OBSIDIAN_VAULT_PATH at all         → 465 passed, 4 skipped
OBSIDIAN_VAULT_PATH=/nonexistent/nope → 465 passed, 4 skipped
```

Deleting it is a shorter diff than making it portable, and moots the question of how a workspace path full of backslashes would have survived pwsh on Windows.

## Verified locally (macOS/arm64)

With `OBSIDIAN_VAULT_PATH` unset, exactly as CI now runs it:

- 465 passed, 4 skipped on **3.11**, **3.12** and **3.13**; coverage 64.89% on each; 60% gate passes
- `actionlint` clean; workflow YAML parses and the matrix expands to the intended 5 jobs
- Lint / Pyright (0 errors) / Bandit (0 issues) / pip-audit re-run on real 3.11

## Explicitly NOT verified

**The macOS and Windows jobs have not run.** GitHub Actions has been in a [major outage](https://www.githubstatus.com/) since 2026-08-06T15:22Z and has produced zero runs for this repository since — this PR will show no checks until that clears.

Windows has never executed this suite. It may surface genuine failures on first green CI (path handling, `os.chmod` semantics, `tempfile` behaviour). That is the point of adding it, but it means **this PR should not be merged on the strength of the local runs alone** — wait for the matrix to actually go green, and treat any Windows failure as a real bug to fix rather than a reason to drop the runner.